### PR TITLE
Initial docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ ENV**/
 
 # mkdocs documentation
 /site
+/_site
 
 # mypy
 .mypy_cache/

--- a/README.md
+++ b/README.md
@@ -60,3 +60,30 @@ python3 ./PolyChron/
 # Or by launching the GUI module manually
 python3 ./PolyChron/gui.py
 ```
+
+## Documentation
+
+Documentation is built using [mkdocs](https://github.com/mkdocs/mkdocs) and some extensions.
+
+Documentation building dependencies are included in the `docs` optional dependencies group.
+They can be installed into the current python environment along with `PolyChron` using `pip`:
+
+```bash
+python3 -m pip install -e .[docs]
+```
+
+Once installed, documentation can be generated and viewed via a local webserver using:
+
+```bash
+python3 -m mkdocs serve
+# or just
+mkdocs serve
+```
+
+Or a static html version can be built into `_site` using:
+
+```bash
+python3 -m mkdocs build
+# pass --no-directory-urls if you wish to view local .html files without a web server
+python3 -m mkdocs build --no-directory-urls
+```

--- a/docs/api/automated_mcmc_ordering_coupling_copy.md
+++ b/docs/api/automated_mcmc_ordering_coupling_copy.md
@@ -1,0 +1,7 @@
+# `automated_mcmc_ordering_coupling_copy.py`
+
+!!! danger
+
+    PolyChron API documentation is intended for developers. For usage please see the [User Guide](../userguide/index.md)
+
+::: PolyChron.automated_mcmc_ordering_coupling_copy

--- a/docs/api/gui.md
+++ b/docs/api/gui.md
@@ -1,0 +1,7 @@
+# gui.py
+
+!!! danger
+
+    PolyChron API documentation is intended for developers. For usage please see the [User Guide](../userguide/index.md)
+
+::: PolyChron.gui

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,8 @@
+# API
+
+!!! danger
+
+    PolyChron API documentation is intended for developers. For usage please see the [User Guide](../userguide/index.md)
+
+- [automated_mcmc_ordering_coupling_copy.py](automated_mcmc_ordering_coupling_copy.md)
+- [gui.py](gui.md)

--- a/docs/assets/css/polychron.css
+++ b/docs/assets/css/polychron.css
@@ -1,0 +1,19 @@
+/* Set some custom css variables to avoid duplication */
+:root {
+    --polychron-blue: #33658a;
+    --polychron-orange: #cc5f00;
+}
+
+/* Set custom colours for the default (i.e. light) theme.
+   see https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/assets/stylesheets/main/_colors.scss */
+[data-md-color-scheme="default"]  {
+    --md-primary-fg-color: var(--polychron-blue);
+    --md-accent-fg-color: var(--polychron-orange);
+}
+
+/* Set custom colours for the slate (i.e. dark) theme.
+   see https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/assets/stylesheets/main/_colors.scss */
+[data-md-color-scheme="slate"] {
+    --md-primary-fg-color: var(--polychron-orange);
+    --md-accent-fg-color: var(--polychron-blue);
+}

--- a/docs/assets/img/logo.png
+++ b/docs/assets/img/logo.png
@@ -1,0 +1,1 @@
+../../../PolyChron/logo.png

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# PolyChron
+
+<!-- Logo path must be inside docs/, but logo is used in both.  -->
+![PolyChron Logo](assets/img/logo.png)
+
+PolyChron is prototype software required to be installed locally on a user’s machine, allowing users to produce multiple chronological models.
+
+In addition, it allows the user to obtain graph theoretic representations of their stratigraphic sequences and prior knowledge within a given hierarchical Bayesian chronological model and save the raw digital data (as collected on-site) along with graph theoretic representations of their models, resulting outputs and supplementary notes produced during such modelling on their machine, thus facilitating future archiving of a complete site archive.
+
+PolyChron is available from [github.com/bryonymoody/PolyChron](https://github.com/bryonymoody/PolyChron)
+
+!!! Danger
+
+    PolyChron's documentation is under development and not yet complete.

--- a/docs/userguide/index.md
+++ b/docs/userguide/index.md
@@ -1,0 +1,28 @@
+# User Guide
+
+!!! warning
+
+    The PolyChron User guide is under development.
+
+## Getting Started
+
+PolyChron is not yet available via `pip` / [PyPI](https://pypi.org/), but can be installed locally from source.
+
+For detailed installation instructions, please see the [PolyChron Readme for local installation instructions](https://github.com/bryonymoody/PolyChron).
+
+## Using PolyChron
+
+There are 4 main sections when using PolyChron.
+
+```mermaid
+graph LR
+    g0[Project Loading];
+    g1[Prior Elicitation];
+    g2[Posterior Inference];
+    g3[Post-MCMC Analysis];
+    g0 --> g1;
+    g1 --> g2;
+    g2 --> g3;
+```
+
+<!-- @todo - describe each section / link to them. -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,71 @@
+site_name: "PolyChron"
+docs_dir: docs
+site_dir: _site
+repo_url: https://github.com/bryonymoody/PolyChron
+repo_name: GitHub
+site_description: PolyChron Documentation 
+
+extra_css:
+  - assets/css/polychron.css
+
+theme:
+  name: "material"
+  locale: en
+  logo: assets/img/logo.png
+  features:
+    - content.code.copy
+    - navigation.indexes 
+    - navigation.expand
+
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+
+nav:
+  - About: index.md
+  - User Guide:
+    - userguide/index.md
+  - API:
+    - api/index.md
+    - api/automated_mcmc_ordering_coupling_copy.md
+    - api/gui.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github 
+      link: https://github.com/bryonymoody
+
+plugins: 
+- mkdocstrings
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.tasklist
+  - pymdownx.superfences:
+      custom_fences:
+        # Enable Mermaid, via the material theme
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,12 @@ dependencies = [
     "ttkthemes",
 ]
 
+[project.optional-dependencies]
+docs = [
+    "mkdocstrings[python]>=0.18",
+    "mkdocs-material>=9.5.0",
+]
+
 [project.urls]
 # Documentation = "https://bryonymoody.github.io/PolyChron"
 Repository = "https://github.com/bryonymoody/PolyChron"


### PR DESCRIPTION
Add initial mkdocs based documentation

- Adds python optional depenedncy group 'docs' with mkdocs + other dependencies
- Adds mkdocs.yml with initial documentation setup
- Adds simple documentation homepage
- Adds very start of userguide, to be expanded later
- Adds auto generated api documenation, with a warning that it is not intended use / likely to change
- MKdocs-material theme customisation using colours from the existing polychron logo
- Symlinks the logo into the docs directory so it can be used in the documentation.
  - This may need to be replaced by a copy for windows support, or an mkdocs plugin to copy the file at build time

Closes #27