### PR TITLE
Initial PyTest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,19 @@ python3 -m mkdocs build
 # pass --no-directory-urls if you wish to view local .html files without a web server
 python3 -m mkdocs build --no-directory-urls
 ```
+
+## Tests
+
+Tests are implemented using `pytest`, which can be installed as part of the `test` optional dependencies via:
+
+```bash
+python3 -m pip install .[test]
+```
+
+Once installed, unit tests can be executed via `pytest` from the root directory
+
+```bash
+python3 -m pytest
+# or
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ docs = [
     "mkdocstrings[python]>=0.18",
     "mkdocs-material>=9.5.0",
 ]
+test = [
+    "pytest>=6.0"
+]
 
 [project.urls]
 # Documentation = "https://bryonymoody.github.io/PolyChron"
@@ -50,3 +53,14 @@ Issues = "https://github.com/bryonymoody/PolyChron/issues"
 
 [project.gui-scripts]
 polychron = "PolyChron.gui:main"
+
+# pytest options
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = [
+    "-ra -q",
+    "--import-mode=importlib",
+]
+testpaths = [
+    "tests",
+]

--- a/tests/PolyChron/test_gui.py
+++ b/tests/PolyChron/test_gui.py
@@ -1,0 +1,14 @@
+# @note - this will currently cause a window to open and require working tkinter.
+import PolyChron.gui
+import pathlib
+
+class TestGUI:
+
+    def test_POLYCHRON_PROJECTS_DIR(self):
+        """Ensure that the global variable containing the path to the users' projects directory is at the expected location.
+
+        @note - this is mostly an example test for now, and will likely be removed / moved during refactoring.
+        """
+        # Check that the projects dir global scoped variable is in the correct location
+        expected_path = (pathlib.Path.home() / "Documents/Pythonapp_tests/projects").resolve()
+        assert PolyChron.gui.POLYCHRON_PROJECTS_DIR == expected_path


### PR DESCRIPTION
Sets up pytest for programatic testing of PolyChron

- Adds pytest to an optional dependency group 'test' in pyproject.toml
- Sets pytest ini_options values in pyproject.toml
- Creates tests/PolyChron/test_gui.py with an initial basic test to show usage/confirm pytest is functional
  - Prior to refactoring, this will cause a window to appear then close immediately.
- Adds testing dependency installation + usage instructions to readme.md

Closes #29