### PR TITLE
Setup linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,15 @@ PolyChron has several non-python dependencies, which must be installed manually:
         ```
 
 PolyChron can then be installed into your python environment using `pip`.
-Using an editable installation (`-e` / `--editable`) is preferred for development.
 
 ```bash
-python3 -m pip install -e .
+python3 -m pip install .
+```
+
+If you are installing PolyChron from source for as a developer, consider using an editable installation (`-e` / `--editable`) and installing the `dev`, `docs` and `test` extras (which are described in subsequent sections).
+
+```bash
+python3 -m pip install -e .[dev,docs,test]
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ PolyChron has several non-python dependencies, which must be installed manually:
         apt-get install python3-tk
         ```
 
-<!-- @todo - non python dependencies? Graphviz? Tikz? -->
-
 PolyChron can then be installed into your python environment using `pip`.
 Using an editable installation (`-e` / `--editable`) is preferred for development.
 

--- a/README.md
+++ b/README.md
@@ -101,3 +101,17 @@ python3 -m pytest
 # or
 pytest
 ```
+
+## Linting
+
+Linting is handled using [`ruff`](https://github.com/astral-sh/ruff) which can be installed as part of the `dev` extras.
+
+> **Note**: `automated_mcmc_ordering_coupling.py` and `gui.py` are currently excluded from linting
+
+Ruff can then be invoked using:
+
+```bash
+python3 -m ruff check
+# or
+ruff check
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "ttkthemes",
 ]
 
+# When widely supported, it would be better to leverage [dependency-groups] than optional-extras for at least dev. https://packaging.python.org/en/latest/specifications/dependency-groups
 [project.optional-dependencies]
 docs = [
     "mkdocstrings[python]>=0.18",
@@ -44,6 +45,9 @@ docs = [
 ]
 test = [
     "pytest>=6.0"
+]
+dev = [
+    "ruff"
 ]
 
 [project.urls]
@@ -64,3 +68,15 @@ addopts = [
 testpaths = [
     "tests",
 ]
+
+# Linter configuration
+[tool.ruff]
+line-length = 120
+indent-width = 4
+# Exclude pre-existing files until they have intentionally been linted
+extend-exclude = [
+    "PolyChron/automated_mcmc_ordering_coupling_copy.py",
+    "PolyChron/gui.py",
+]
+# Select which ruff rules to apply when linting.
+lint.select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
- Adds initial linting setup using ruff
  - New optional-dependency group `dev` which includes `ruff
  - Initial basic linting configuration in pyproject.toml
  - Linting disabled for pre-exisitng files, to allow linting of newly created files until linting is applied to the larger files
- Removes already addressed comment from README.md
- Adjusts suggested installation instructions to suggest installing `-e .[dev,docs,test]` for developers