### PR TITLE
Add basic CLI with `-h/--help` and `--version`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,15 +67,15 @@ jobs:
         run: |
           python3 -c "from importlib.metadata import version; print(version('PolyChron'))"
 
-      # Run the PolyChron module
-      # - name: Run PolyChron as a module
-      #   run: |
-      #     python3 -m PolyChron
+      # Run the PolyChron module to ensure it is installed. use --help to prevent gui hanging
+      - name: Run PolyChron as a module
+        run: |
+          python3 -m PolyChron --help
 
-      # Run the PolyChron binary
-      # - name: Run PolyChron via the executable script
-      #   run: |
-      #     polychron
+      # Run the polychron binary to ensure it is installed. use --version to prevent gui hanging
+      - name: Run PolyChron via the executable script
+        run: |
+          polychron --version
 
       # Install the package into the current python environment with the test extras
       - name: Install PolyChron with extras

--- a/PolyChron/gui.py
+++ b/PolyChron/gui.py
@@ -45,6 +45,7 @@ import csv
 # from svglib.svglib import svg2rlg
 # import cairosvg
 from importlib.metadata import version # requires python >= 3.8
+import argparse
 old_stdout = sys.stdout
 
 
@@ -3997,10 +3998,36 @@ MAIN_FRAME.option_add("*Font", default_font)
 MAIN_FRAME.geometry("2000x1000")
 MAIN_FRAME.title(f"PolyChron {version('PolyChron')}")
 
+def parse_cli(argv=None):
+    """Parse and return command line arguments
+
+    Args:
+        argv (list[str] or None): optional list of command line parameters to parse. If None, sys.argv is used by `argparse.ArgumentParser.parse_args`
+
+    Returns:
+        (argparse.Namespace): Namespace object with arguments set as attributes, as returned by `argparse.ArgumentParser.parse_args()`
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", action="store_true", help="show version information and exit")
+    args = parser.parse_args(argv)
+    return args
+
+def print_version():
+    """Print the version of PolyChron to stdout
+
+    Note:
+        For editable installs the printed value may be incorrect 
+    """
+    print(f"PolyChron {version('PolyChron')}")
+
 def main():
     """Main method as the entry point for launching the GUI
     """
-    MAIN_FRAME.mainloop() 
+    args = parse_cli()
+    if args.version:
+        print_version()
+    else:
+        MAIN_FRAME.mainloop() 
 
 # If this script is executed directly, run the main method
 if __name__ == "__main__":

--- a/tests/PolyChron/test_gui.py
+++ b/tests/PolyChron/test_gui.py
@@ -1,4 +1,5 @@
 # @note - this will currently cause a window to open and require working tkinter.
+import pytest
 import PolyChron.gui
 import pathlib
 
@@ -12,3 +13,50 @@ class TestGUI:
         # Check that the projects dir global scoped variable is in the correct location
         expected_path = (pathlib.Path.home() / "Documents/Pythonapp_tests/projects").resolve()
         assert PolyChron.gui.POLYCHRON_PROJECTS_DIR == expected_path
+
+
+    def test_parse_cli_noargs(self):
+        """Ensure that parse_cli with no cli arguments sets expected values and does not call sys.exit
+        """
+        try:
+            args = PolyChron.gui.parse_cli([])
+            # args.version should be false by default
+            assert not args.version
+        except SystemExit:
+            pytest.fail("SystemExit exception raised")
+
+    def test_parse_cli_version(self):
+        """Ensure that parse_cli with --version prints something and does not call sys.exit
+        """
+        try:
+            args = PolyChron.gui.parse_cli(["--version"])
+            # args.version should now be True
+            assert args.version
+        except SystemExit:
+            pytest.fail("SystemExit exception raised")
+
+    def test_parse_cli_version_h(self, capsys):
+        """Ensure that parse_cli with -h prints something and then would trigger a sys.exit with a 0 error code (success)
+        """
+        with pytest.raises(SystemExit) as e:
+            _ = PolyChron.gui.parse_cli(["-h"])
+        assert e.type is SystemExit
+        assert e.value.code == 0
+        assert len(capsys.readouterr()) != 0
+
+    def test_parse_cli_version_help(self, capsys):
+        """Ensure that parse_cli with -h assert len  something and then would trigger a sys.exit with a 0 error code (success)
+        """
+        with pytest.raises(SystemExit) as e:
+            _ = PolyChron.gui.parse_cli(["--help"])
+        assert e.type is SystemExit
+        assert e.value.code == 0
+        assert len(capsys.readouterr()) != 0
+
+    def test_print_Version(self, capsys):
+        """Ensure that calls to print_version succeed and print something to stdout. 
+        
+        @note print statement content is not explicitly checked for now.
+        """
+        PolyChron.gui.print_version()
+        assert len(capsys.readouterr()) != 0


### PR DESCRIPTION
- adds -h/--help to print help information about running polychron
- adds --version to print the polychron version to stdout. This will be the version last installed for editable installs
- adds tests for new functionality
- enables CI checking of execution via python3 -m PolyChron and polychron now non-blocking execution is possible

Closes #45