### PR TITLE
Lint gui.py

### DIFF
--- a/PolyChron/gui.py
+++ b/PolyChron/gui.py
@@ -1282,10 +1282,10 @@ class popupWindow9(object):
           base_prev_phase = self.master.prev_phase
           base_post_phase = self.master.post_phase
           base_context_no_unordered = self.master.context_no_unordered
-          RCD_EST = [int(list(self.master.datefile["date"])[list(self.master.datefile["context"]).index(i)]) for i in base_context_no]
-          RCD_ERR = [int(list(self.master.datefile["error"])[list(self.master.datefile["context"]).index(i)]) for i in base_context_no]
-          A = max(min(RCD_EST) - 4*max(RCD_EST), 0)
-          P = min(max(RCD_EST) + 4*max(RCD_EST), 50000)
+          # RCD_EST = [int(list(self.master.datefile["date"])[list(self.master.datefile["context"]).index(i)]) for i in base_context_no]
+          # RCD_ERR = [int(list(self.master.datefile["error"])[list(self.master.datefile["context"]).index(i)]) for i in base_context_no]
+          # A = max(min(RCD_EST) - 4*max(RCD_EST), 0)
+          # P = min(max(RCD_EST) + 4*max(RCD_EST), 50000)
 
           self.rc_llhds_dict = {}
           for i, j, k in model_list_labels:
@@ -1499,7 +1499,7 @@ class popupWindow10(object):
           self.path = path
           # for i in range(20,140):
           #     katz_df_subset = katz_df_test.sort_values(by='pagerank', ascending = False).head(i)
-          ref_wd = os.getcwd()
+        #   ref_wd = os.getcwd()
      #     con_list = list(katz_df_test['context'])
           base_cont_type =  self.master.CONT_TYPE
           base_key_ref = self.master.key_ref

--- a/PolyChron/gui.py
+++ b/PolyChron/gui.py
@@ -2990,7 +2990,8 @@ class StartPage(tk.Frame):
         bbox = self.littlecanvas.bbox(self.container)  # get image area
         if bbox[0] < x_zoom < bbox[2] and bbox[1] < y_zoom < bbox[3]:
             pass  # Ok! Inside the image
-        else: return  # zoom only inside image area
+        else: 
+            return  # zoom only inside image area
         scale = 1.0
         # Respond to Linux (event.num) or Windows (event.delta) wheel event
         if event.num == 5 or event.delta == -120:  # scroll down
@@ -3016,7 +3017,8 @@ class StartPage(tk.Frame):
         bbox = self.littlecanvas2.bbox(self.container2)  # get image area
         if bbox[0] < x_zoom < bbox[2] and bbox[1] < y_zoom < bbox[3]:
             pass  # Ok! Inside the image
-        else: return  # zoom only inside image area
+        else:
+            return  # zoom only inside image area
         scale2 = 1.0
         # Respond to Linux (event.num) or Windows (event.delta) wheel event
         if event.num == 5 or event.delta == -120:  # scroll down
@@ -3564,7 +3566,8 @@ class PageOne(tk.Frame):
         bbox = self.littlecanvas2.bbox(self.container2)  # get image area
         if bbox[0] < x_zoom < bbox[2] and bbox[1] < y_zoom < bbox[3]:
             pass  # Ok! Inside the image
-        else: return  # zoom only inside image area
+        else:
+            return  # zoom only inside image area
         scale2 = 1.0
         # Respond to Linux (event.num) or Windows (event.delta) wheel event
         if event.num == 5 or event.delta == -120:  # scroll down
@@ -3814,7 +3817,8 @@ class PageTwo(object):
         bbox = self.graphcanvas.bbox(self.container)  # get image area
         if bbox[0] < x_zoom < bbox[2] and bbox[1] < y_zoom < bbox[3]:
             pass  # Ok! Inside the image
-        else: return  # zoom only inside image area
+        else:
+            return  # zoom only inside image area
         scale2 = 1.0
         # Respond to Linux (event.num) or Windows (event.delta) wheel event
         if event.num == 5 or event.delta == -120:  # scroll down
@@ -3840,7 +3844,8 @@ class PageTwo(object):
         bbox = self.graphcanvas.bbox(self.container)  # get image area
         if bbox[0] < x_zoom < bbox[2] and bbox[1] < y_zoom < bbox[3]:
             pass  # Ok! Inside the image
-        else: return  # zoom only inside image area
+        else:
+            return  # zoom only inside image area
         scale2 = 1.0
         # Respond to Linux (event.num) or Windows (event.delta) wheel event
         if event.num == 5 or event.delta == -120:  # scroll down

--- a/PolyChron/gui.py
+++ b/PolyChron/gui.py
@@ -7,13 +7,6 @@ Created on Sun Aug 15 17:43:25 2021
 """
 import os
 import pathlib
-# Get the absolute path to a directory in the users home dir
-POLYCHRON_PROJECTS_DIR = (pathlib.Path.home() / "Documents/Pythonapp_tests/projects").resolve()
-# Ensure the directory exists (this is a little aggressive)
-POLYCHRON_PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
-# Change into the projects dir
-os.chdir(POLYCHRON_PROJECTS_DIR)
-
 import tkinter as tk
 from tkinter import ttk
 import copy
@@ -46,6 +39,12 @@ import csv
 # import cairosvg
 from importlib.metadata import version # requires python >= 3.8
 import argparse
+# Get the absolute path to a directory in the users home dir
+POLYCHRON_PROJECTS_DIR = (pathlib.Path.home() / "Documents/Pythonapp_tests/projects").resolve()
+# Ensure the directory exists (this is a little aggressive)
+POLYCHRON_PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+# Change into the projects dir
+os.chdir(POLYCHRON_PROJECTS_DIR)
 old_stdout = sys.stdout
 
 

--- a/PolyChron/gui.py
+++ b/PolyChron/gui.py
@@ -128,7 +128,7 @@ def ellipsefunc(i):
 def node_coords_fromjson(graph):
     """Gets coordinates of each node"""
     global phase_true
-    if ('pydot' in str(type(graph))) == True:
+    if ('pydot' in str(type(graph))):
         graphs = graph
     else:   
         graphs = nx.nx_pydot.to_pydot(graph)
@@ -342,14 +342,14 @@ def del_empty_phases(phi_ref, del_phase, phasedict):
         rels_list = [i for i in phasedict.keys() if j in i]
         for rels in rels_list:
             if rels[0] == j:
-                if rels[1] in del_phase == True:
+                if rels[1] in del_phase:
                     del_phase_dict_1[j]['lower'] = del_phase_dict_1[rels[1]]['lower']
     del_phase.reverse()
     for k in del_phase:
         rels_list = [i for i in phasedict.keys() if k in i]
         for rels in rels_list:
             if rels[1] == k:
-                if rels[0] in del_phase == True:
+                if rels[0] in del_phase:
                     del_phase_dict_1[k]['upper'] = del_phase_dict_1[rels[0]]['upper']
     new_phase_rels = [[del_phase_dict_1[l]['upper'],
                        del_phase_dict_1[l]['lower']] for l in del_phase_dict_1.keys()
@@ -365,24 +365,24 @@ def phase_rels_delete_empty(file_graph, new_phase_rels, p_list, phasedict, phase
     for p in p_list:
         relation = phasedict[p]
         if relation == 'gap':
-            if (p[0] in graph_data[1][2]) == False:
+            if p[0] not in graph_data[1][2]:
                 phasedict.pop[p]
                 null_phases.append(p)
-            elif (p[1] in graph_data[1][2]) == False:
+            elif p[1] not in graph_data[1][2]:
                 null_phases.append(p)
             else:
                 file_graph.add_edge("a_" + str(p[0]), "b_" + str(p[1]), arrowhead='none')
         if relation == 'overlap':
-            if (p[0] in graph_data[1][2]) == False:
+            if p[0] not in graph_data[1][2]:
                 null_phases.append(p)
-            elif (p[1] in graph_data[1][2]) == False:
+            elif p[1] not in graph_data[1][2]:
                 null_phases.append(p)
             else:
                 file_graph.add_edge("b_" + str(p[1]), "a_" + str(p[0]), arrowhead='none')
         if relation == "abutting":
-            if (p[0] in graph_data[1][2]) == False:
+            if p[0] not in graph_data[1][2]:
                 null_phases.append(p)
-            elif (p[1] in graph_data[1][2]) == False:
+            elif p[1] not in graph_data[1][2]:
                 null_phases.append(p)
             else:
                 file_graph = nx.contracted_nodes(file_graph, "a_" + str(p[0]), "b_" + str(p[1]))
@@ -403,14 +403,14 @@ def chrono_edge_add(file_graph, graph_data, xs_ys, phasedict, phase_trck, post_d
     phase_norm, node_list = graph_data[1][0], graph_data[1][1]
     all_node_phase = dict(zip(node_list, phase_norm))
     for i in node_list: #loop adds edges between phases
-        if (i in xs) == False:
-            if (i in ys) == False:
+        if i not in xs:
+            if i not in ys:
                 file_graph.add_edge("b_" + str(all_node_phase[i]), i, arrowhead='none')
                 file_graph.add_edge(i, "a_" + str(all_node_phase[i]), arrowhead='none')
             else:
                 file_graph.add_edge(i, "a_" + str(all_node_phase[i]), arrowhead='none')
-        elif (i in xs) == True:
-            if (i in ys) == False:
+        elif (i in xs):
+            if i not in ys:
                 file_graph.add_edge("b_" + str(all_node_phase[i]), i, arrowhead='none')
     if phasedict != None:
         p_list = list(set(phase_trck)) #phases before any get removed due to having no dates
@@ -987,7 +987,7 @@ class popupWindow3(object):
         else:
             self.phi_ref = list(self.step_1[0][1][2])
         self.post_phase.append("end")
-        del_phases = [i for i in self.phi_ref if i in phase_list == False]
+        del_phases = [i for i in self.phi_ref if i not in phase_list]
         ref_list = []
         for i in del_phases:
             ref = np.where(np.array(self.phi_ref) == i)[0][0]
@@ -1368,7 +1368,7 @@ class popupWindow9(object):
                  for k in edges1:
                      if k not in graph_check.edges():
                          self.master.chrono_dag.remove_edge(k[0], k[1])
-              if (phase in self.master.key_ref) == False:
+              if phase not in self.master.key_ref:
                   self.master.phi_ref.pop(phase_ref)                                
                   if self.master.prev_phase[phase_ref] == 'start':
                       phase_node = [i for i in self.master.chrono_dag.nodes() if "b_"+str(phase) in i]
@@ -1571,8 +1571,8 @@ class popupWindow10(object):
               katz_df_test = pd.read_csv(path + "/" + refmodel + "/katz_centr_chrono.csv") 
           katz_df_test = katz_df_test[['context', 'pagerank']]
           katz_df_test['context'] = katz_df_test['context'].astype(str)
-          katz_df_test = katz_df_test.loc[(katz_df_test["context"].str.contains("a") == False)]
-          katz_df_test = katz_df_test.loc[(katz_df_test["context"].str.contains("b") == False)]
+          katz_df_test = katz_df_test.loc[(not katz_df_test["context"].str.contains("a"))]
+          katz_df_test = katz_df_test.loc[(not katz_df_test["context"].str.contains("b"))]
           katz_df_test = katz_df_test.transpose()
           katz_df = katz_df_test.rename(columns=katz_df_test.iloc[0]).drop(katz_df_test.index[0]).reset_index(drop=True)    
           ll_over_df = pd.read_csv(path + "/" + refmodel + "/overlap_df.csv")
@@ -1617,7 +1617,7 @@ class popupWindow10(object):
           return contexts
         
       def graph_adjust(self, phase, phase_ref):
-              if (phase in self.master.key_ref) == False:
+              if phase not in self.master.key_ref:
                   self.master.phi_ref.pop(phase_ref)                                
                   if self.master.prev_phase[phase_ref] == 'start':
                       phase_node = [i for i in self.master.chrono_dag.nodes() if "b_"+str(phase) in i]
@@ -1881,7 +1881,7 @@ class load_Window(object):
             os.makedirs(dirs5)
             os.chdir(dirs)
             proj_dir = os.path.join(POLYCHRON_PROJECTS_DIR, folder_dir)
-            if load == True:
+            if load:
                 for F in (StartPage, PageOne):
                     page_name = F.__name__
                     frame = F(parent=self.master.container, controller=self.master)
@@ -2495,7 +2495,7 @@ class StartPage(tk.Frame):
                     edges = []
                     for i in range(len(self.stratfile)):
                         a = tuple(self.stratfile.iloc[i, :])
-                        if pd.isna(a[1]) == False:
+                        if not pd.isna(a[1]):
                             edges.append(a)
                     G.add_edges_from(edges, arrowhead="none")
                     self.graph = G
@@ -3936,24 +3936,24 @@ class PageTwo(object):
         node = self.nodecheck(x_scal, y_scal)
         outline = nx.get_node_attributes(self.graphcopy, 'color')
         #changes colour of the node outline to represent: intrustive (green), residual (orange) or none (black)
-        if ((node in self.resid_list) == True) and (self.modevariable != 'intru'):
+        if (node in self.resid_list) and (self.modevariable != 'intru'):
             self.resid_list.remove(node)
             outline[node] = 'black'
-        elif ((node in self.resid_list) == True) and (self.modevariable == 'intru'):
+        elif (node in self.resid_list) and (self.modevariable == 'intru'):
             self.resid_list.remove(node)
             outline[node] = 'green'
             self.intru_list.append(node)
-        elif ((node in self.intru_list) == True) and (self.modevariable != 'resid'):
+        elif (node in self.intru_list) and (self.modevariable != 'resid'):
             self.intru_list.remove(node)
             outline[node] = 'black'
-        elif ((node in self.intru_list) == True) and (self.modevariable == 'resid'):
+        elif (node in self.intru_list) and (self.modevariable == 'resid'):
             self.intru_list.remove(node)
             self.resid_list.append(node)
             outline[node] = 'orange'
-        elif (self.modevariable == 'resid') and ((node in self.resid_list) == False):
+        elif (self.modevariable == 'resid') and (node not in self.resid_list):
             self.resid_list.append(node)
             outline[node] = 'orange'
-        elif self.modevariable == 'intru'and ((node in self.intru_list) == False):
+        elif self.modevariable == 'intru'and (node not in self.intru_list):
             self.intru_list.append(node)
             outline[node] = 'green'
         self.resid_label = ttk.Label(self.residcanvas, text=str(self.resid_list).replace("'", "")[1:-1])

--- a/PolyChron/gui.py
+++ b/PolyChron/gui.py
@@ -412,7 +412,7 @@ def chrono_edge_add(file_graph, graph_data, xs_ys, phasedict, phase_trck, post_d
         elif (i in xs):
             if i not in ys:
                 file_graph.add_edge("b_" + str(all_node_phase[i]), i, arrowhead='none')
-    if phasedict != None:
+    if phasedict is not None:
         p_list = list(set(phase_trck)) #phases before any get removed due to having no dates
 
         phase_nodes.append('a_'+ str(p_list[0][0]))
@@ -515,7 +515,7 @@ def edge_of_phase(test1, pset, node_list, node_info):
     y_l = []
     mydict = {}
     phase_tracker = []
-    if FILE_INPUT != None:
+    if FILE_INPUT is not None:
         for i in enumerate(pset):
             temp_nodes_list = []
             for j in enumerate(node_list):
@@ -551,7 +551,7 @@ def phase_info_func(file_graph):
     node_list = list(file_graph.nodes)
     nd = dict(file_graph.nodes(data=True))
     node_info = [nd[i] for i in node_list]
-    if FILE_INPUT != None:
+    if FILE_INPUT is not None:
         phase = nx.get_node_attributes(file_graph, "fillcolor")
         phase_norm = [phase[ph][phase[ph].rfind("/")+1:len(phase[ph])] for ph in phase]
 # ####code to get colours####
@@ -789,7 +789,7 @@ class popupWindow3(object):
         self.node_del_tracker = [] #empty node tracker 
         #checks for each context and if there isn't node or phase info, it deletes it
         for i in nodes:
-            if phasedict[i] == None:
+            if phasedict[i] is not None:
                 self.node_del_tracker.append(i)
             elif datadict[i] == [None, None]:
                 self.node_del_tracker.append(i)
@@ -1775,7 +1775,7 @@ class load_Window(object):
         self.initscreen()
         
     def initscreen(self):
-        [x.destroy() for x in [self.greeting, self.b, self.c, self.back, self.back1, self.l, self.MyListBox, self.text_1, self.user_input] if x != None]
+        [x.destroy() for x in [self.greeting, self.b, self.c, self.back, self.back1, self.l, self.MyListBox, self.text_1, self.user_input] if x is not None]
         self.maincanvas.update() 
         image1 = Image.open(SCRIPT_DIR / "logo.png")
         logo = ImageTk.PhotoImage(image1.resize((360, 70)))
@@ -1801,7 +1801,7 @@ class load_Window(object):
     def load_proj(self):
         global proj_dir
         os.chdir(POLYCHRON_PROJECTS_DIR)
-        [x.destroy() for x in [self.label1, self.greeting, self.b, self.c, self.back, self.l, self.back1, self.MyListBox, self.text_1, self.user_input] if x != None]
+        [x.destroy() for x in [self.label1, self.greeting, self.b, self.c, self.back, self.l, self.back1, self.MyListBox, self.text_1, self.user_input] if x is not None]
         self.maincanvas.update()
 
         self.l=tk.Label(self.maincanvas, text="Select project", bg = 'white', font = ('helvetica 14 bold'), fg = '#2F4858' )
@@ -1826,8 +1826,8 @@ class load_Window(object):
     
     def load_model(self, direc):
         global proj_dir
-        [x.destroy() for x in [self.greeting, self.label1, self.b, self.c, self.back, self.back1, self.l, self.MyListBox] if x != None] 
-        if self.selected_langs == None:
+        [x.destroy() for x in [self.greeting, self.label1, self.b, self.c, self.back, self.back1, self.l, self.MyListBox] if x is not None] 
+        if self.selected_langs is None:
             path = direc
         else:    
             path = os.getcwd() + "/" + self.selected_langs 
@@ -1901,7 +1901,7 @@ class load_Window(object):
             self.cleanup()
 
     def new_proj(self):
-        [x.destroy() for x in [self.greeting, self.label1, self.b, self.back1, self.c, self.back, self.l, self.MyListBox, self.text_1, self.user_input] if x != None]
+        [x.destroy() for x in [self.greeting, self.label1, self.b, self.back1, self.c, self.back, self.l, self.MyListBox, self.text_1, self.user_input] if x is not None]
         self.maincanvas.update()
         self.folder = tk.StringVar() # Receiving user's folder_name selection
         self.text_1 = tk.Label(self.maincanvas, text = "Input project name:" ,bg = 'white', font = ('helvetica 14 bold'), fg = '#2F4858' )
@@ -1915,7 +1915,7 @@ class load_Window(object):
         self.back.place(relx = 0.21, rely = 0.01)
         
     def new_model(self, folder_dir, load = True):
-        [x.destroy() for x in [self.greeting, self.label1, self.b, self.c, self.back, self.back1, self.l, self.MyListBox, self.text_1, self.user_input] if x != None]
+        [x.destroy() for x in [self.greeting, self.label1, self.b, self.c, self.back, self.back1, self.l, self.MyListBox, self.text_1, self.user_input] if x is not None]
         self.maincanvas.update()
         self.model = tk.StringVar() # Receiving user's folder_name selection
         self.text_1 = tk.Label(self.maincanvas, text = "Input model name:" ,bg = 'white', font = ('helvetica 14 bold'), fg = '#2F4858' )
@@ -3332,7 +3332,7 @@ class PageOne(tk.Frame):
         if len(self.phase_len_nodes) == 1:
             if self.variable.get() == "Get time elapsed between "+ str(self.phase_len_nodes[0]) + ' and another context':
                 self.phase_len_nodes = np.append(self.phase_len_nodes, x)
-                if self.canvas_plt != None:
+                if self.canvas_plt is not None:
                     self.canvas_plt.get_tk_widget().pack_forget()
         #        font = {'size': 11}
                 # using rc function
@@ -3439,7 +3439,7 @@ class PageOne(tk.Frame):
         global mcmc_check
         startpage = self.controller.get_page('StartPage')
         if mcmc_check == 'mcmc_loaded':
-            if self.canvas_plt != None:
+            if self.canvas_plt is not None:
                 self.canvas_plt.get_tk_widget().pack_forget()
                 self.toolbar.destroy()
             fig = Figure(figsize=(8, min(30, len(self.results_list)*3)),
@@ -3708,7 +3708,7 @@ class PageTwo(object):
         scroll_bar2.pack(side=tk.RIGHT)
         label3 = ttk.Label(self.canvas, text='Intrusive Contexts')
         label3.place(relx=0.4, rely=0.52)
-        if startpage.graph != None:
+        if startpage.graph is not None:
             self.graphcopy = self.load_graph()
             self.imscale2  = min(921/self.image.size[0], 702/self.image.size[1])
             self.graphcanvas.scale('all', 0, 0, self.delta2, self.delta2)  # rescale all canvas objects       
@@ -3904,7 +3904,7 @@ class PageTwo(object):
         startpage.update_idletasks()
 
         node_inside = "no node"
-        if self.graphcopy != None:
+        if self.graphcopy is not None:
             #gets node coordinates from the graph
             node_df_con = node_coords_fromjson(self.graphcopy)
             #forms a dataframe from the dicitonary of coords

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,6 @@ indent-width = 4
 # Exclude pre-existing files until they have intentionally been linted
 extend-exclude = [
     "PolyChron/automated_mcmc_ordering_coupling_copy.py",
-    "PolyChron/gui.py",
 ]
 # Select which ruff rules to apply when linting.
 lint.select = ["E4", "E7", "E9", "F"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,7 @@ extend-exclude = [
 ]
 # Select which ruff rules to apply when linting.
 lint.select = ["E4", "E7", "E9", "F"]
+# But ignore some of them
+lint.ignore = [
+    "E741", # https://docs.astral.sh/ruff/rules/ambiguous-variable-name/
+]


### PR DESCRIPTION
Enables `bPolyChron/gui.py` for litning, and addresses lint errors.

- [E402](https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file/)
- [E712](https://docs.astral.sh/ruff/rules/true-false-comparison/)
- [E711](https://docs.astral.sh/ruff/rules/none-comparison/)
- [E701](https://docs.astral.sh/ruff/rules/multiple-statements-on-one-line-colon/)
- [F841](https://docs.astral.sh/ruff/rules/unused-variable/)
- Suppresses [E741](https://docs.astral.sh/ruff/rules/ambiguous-variable-name/) errors (`l`, `O` and `I` are ambiguos)  

Closes #41 