### PR TITLE
Fix error introduced during linting in b2ccab7

### DIFF
--- a/PolyChron/gui.py
+++ b/PolyChron/gui.py
@@ -789,7 +789,7 @@ class popupWindow3(object):
         self.node_del_tracker = [] #empty node tracker 
         #checks for each context and if there isn't node or phase info, it deletes it
         for i in nodes:
-            if phasedict[i] is not None:
+            if phasedict[i] is None:
                 self.node_del_tracker.append(i)
             elif datadict[i] == [None, None]:
                 self.node_del_tracker.append(i)


### PR DESCRIPTION
Fixes the 'Adding group relationships' dialogue, which was broken during linting by unintentiaonly replacing ` == None` with `is not None`