### PR TITLE
Fix: `networkx` < 3.4 errors with pydot and `:` 

### DIFF
--- a/PolyChron/gui.py
+++ b/PolyChron/gui.py
@@ -39,6 +39,7 @@ import csv
 # import cairosvg
 from importlib.metadata import version # requires python >= 3.8
 import argparse
+import packaging.version
 # Get the absolute path to a directory in the users home dir
 POLYCHRON_PROJECTS_DIR = (pathlib.Path.home() / "Documents/Pythonapp_tests/projects").resolve()
 # Ensure the directory exists (this is a little aggressive)
@@ -1033,6 +1034,13 @@ class popupWindow3(object):
             self.graphcopy.add_edge(a[0], a[1], arrowhead = 'none')
         for b in edge_remove:
             self.graphcopy.remove_edge(b[0], b[1])
+
+        # networkx.drawing.nx_pydot.write_dot from networkx < 3.4 does not quote node attributes correctly if they contain characters such as :. Networkx 3.4 is only available for pythono >= 3.10, so a workaround is required for python 3.9 users.
+        if packaging.version.parse(nx.__version__) < packaging.version.parse("3.4.0"):
+            # Remove the contraction attribute from nodes.
+            for i in nodes:
+                self.graphcopy.nodes[i].pop("contraction", None)
+
         write_dot(self.graphcopy, 'fi_new_chrono')
         self.top.destroy()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ dependencies = [
     "graphviz",
     "numpy<2",
     "matplotlib",
-    "networkx",
+    "networkx>=3.4; python_version >= '3.10'", # required for https://github.com/networkx/networkx/pull/7588, but not available for py 3.9
+    "networkx>=2; python_version < '3.10'",
+    "packaging",
     "pandas<2",
     "pydot",
     "ttkthemes",


### PR DESCRIPTION
Add workaround for networkx/pydot incompatibilty resulting in errors with unquoted `:`

- Adds dependency on packaging.version to pyproject.toml
- Updates networkx dependency to be >=3.4 for python3.10+, allow any version for 3.9
- Remove contraction attributes from nodes when networkx<3.4 is used

Closes #57 