### PR TITLE
Dynamic version with editbale install support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "polychron"
-version = "0.2.0"
+dynamic = ["version"]
 requires-python = ">= 3.9"
 authors = [
     {name = "Bryony Moody", email = "bryony.moody@sheffield.ac.uk"},
@@ -65,6 +65,9 @@ Issues = "https://github.com/bryonymoody/PolyChron/issues"
 
 [project.scripts]
 polychron = "polychron.entrypoint:main"
+
+[tool.hatch.version]
+path = "src/polychron/_version.py"
 
 # pytest options
 [tool.pytest.ini_options]

--- a/src/polychron/GUIApp.py
+++ b/src/polychron/GUIApp.py
@@ -6,12 +6,12 @@ import re
 import sys
 import tkinter as tk
 import tkinter.font as tkFont
-from importlib.metadata import version
 from tkinter import ttk
 from typing import Any, Dict
 
 from ttkthemes import ThemedStyle, ThemedTk
 
+from . import __version__
 from .Config import Config, get_config
 from .interfaces import Mediator
 from .models.ProjectSelection import ProjectSelection
@@ -91,7 +91,7 @@ class GUIApp(Mediator):
         Parameters:
             suffix: an optional suffix which will be appended to the default window title
         """
-        title = f"PolyChron {version('polychron')}"
+        title = f"PolyChron {__version__}"
         if suffix is not None and len(str(suffix)) > 0:
             title += f" | {suffix}"
         self.root.title(title)

--- a/src/polychron/__init__.py
+++ b/src/polychron/__init__.py
@@ -1,0 +1,1 @@
+from ._version import __version__ as __version__

--- a/src/polychron/_version.py
+++ b/src/polychron/_version.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import subprocess
+from pathlib import Path
+
+# Define the public version string
+__version__ = "0.2.0"
+
+
+def is_editable_install() -> bool:
+    """Check if the package has been installed in editable mode or not using importlib.
+
+    Returns:
+        Boolean indicating if polychron was installed in editable mode
+    """
+    try:
+        # Get metadata for the installed package and read direct_url.json to check if an editable install
+        distribution = importlib.metadata.distribution("polychron")
+        direct_url = json.loads(distribution.read_text("direct_url.json"))
+        is_editable = direct_url.get("dir_info", {}).get("editable", False)
+        return is_editable
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
+def get_local_install_git_hash() -> str | None:
+    """Get the short git commit hash for the package, if git is installed and the repository is a local install.
+
+    Returns:
+        The short git commit hash if available, otherwise None
+    """
+    try:
+        # Query package distribution info, to check if editable and find local path
+        distribution = importlib.metadata.distribution("polychron")
+        direct_url = json.loads(distribution.read_text("direct_url.json"))
+        local_path = direct_url.get("url", None)
+        # Return early if not a local filepath, or it does not exist.
+        if not local_path.startswith("file://"):
+            return None
+        package_path = Path(local_path[7:])
+        if not package_path.is_dir():
+            return None
+        # Get the short commit hash
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=package_path,
+        )
+        git_hash = result.stdout.strip()
+        # Check if the working directory is dirty
+        result = subprocess.run(
+            ["git", "diff", "--shortstat"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=package_path,
+        )
+        is_dirty = bool(result.stdout.strip())
+        # If the git repo is dirty (i.e. uncommitted changes) postfix the short hash local version identifier with -dirty
+        if is_dirty:
+            git_hash += ".dirty"
+
+        return git_hash
+
+    except subprocess.CalledProcessError:
+        return None
+
+
+# If the install is an editable install, include a local version number
+if is_editable_install():
+    __version__ = f"{__version__}+editable"
+    if (git_hash := get_local_install_git_hash()) is not None:
+        __version__ = f"{__version__}.{git_hash}"

--- a/src/polychron/entrypoint.py
+++ b/src/polychron/entrypoint.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import argparse
-from importlib.metadata import version
 from typing import Sequence
 
+from . import __version__
 from .Config import Config, get_config
 
 
@@ -47,7 +47,7 @@ def print_version() -> None:
     Note:
         For editable installs the printed value may be incorrect
     """
-    print(f"PolyChron {version('polychron')}")
+    print(f"PolyChron {__version__}")
 
 
 def main() -> None:

--- a/src/polychron/models/MCMCData.py
+++ b/src/polychron/models/MCMCData.py
@@ -1,11 +1,12 @@
 import json
 import pathlib
 from dataclasses import dataclass, field
-from importlib.metadata import version
 from typing import Dict, List, get_type_hints
 
 import pandas as pd
+from packaging.version import Version
 
+from .. import __version__
 from ..util import MonotonicTimer
 
 
@@ -126,7 +127,7 @@ class MCMCData:
                 data[k] = str(v)
 
         indent = 2 if pretty else None
-        return json.dumps({"polychron_version": version("polychron"), "mcmc_data": data}, indent=indent)
+        return json.dumps({"polychron_version": Version(__version__).public, "mcmc_data": data}, indent=indent)
 
     def save(self, path: pathlib.Path, group_df: pd.DataFrame, verbose: bool = False) -> None:
         """Save the current state of this file to the specified path

--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -8,7 +8,6 @@ import pathlib
 import shutil
 import sys
 from dataclasses import dataclass, field
-from importlib.metadata import version
 from inspect import signature
 from typing import Dict, List, Literal, Optional, Tuple, get_type_hints
 
@@ -21,6 +20,7 @@ from networkx.drawing.nx_pydot import write_dot
 from packaging.version import Version
 from PIL import Image, UnidentifiedImageError
 
+from .. import __version__
 from ..automated_mcmc_ordering_coupling_copy import run_MCMC
 from ..Config import get_config
 from ..models.MCMCData import MCMCData
@@ -364,7 +364,7 @@ class Model:
                     data[k] = str(v)
 
         indent = 2 if pretty else None
-        return json.dumps({"polychron_version": version("polychron"), "model": data}, indent=indent)
+        return json.dumps({"polychron_version": Version(__version__).public, "model": data}, indent=indent)
 
     def save(self) -> None:
         """Save the current state of this model to disk at self.path

--- a/tests/polychron/test_GUIApp.py
+++ b/tests/polychron/test_GUIApp.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import pathlib
 import platform
 import tkinter as tk
-from importlib.metadata import version
 from tkinter import ttk
 from unittest.mock import MagicMock, patch
 
 import pytest
 from ttkthemes import ThemedStyle, ThemedTk
 
+from polychron import __version__
 from polychron.Config import Config
 from polychron.GUIApp import GUIApp
 from polychron.models.ProjectSelection import ProjectSelection
@@ -142,7 +142,7 @@ class TestGUIApp:
         """Test the set window title method behaves as intended, by patching ThemedTk.title"""
         app = GUIApp()
 
-        expected_base_title = f"PolyChron {version('polychron')}"
+        expected_base_title = f"PolyChron {__version__}"
 
         # Patch out .title so we can check it was called as expected
         with patch("polychron.GUIApp.ThemedTk.title") as mock_root_title:


### PR DESCRIPTION
Dynamic version with editbale install support

- Switch from a fixed package version in pyproject.toml, to a version defined in _verison.py.
- Adds polychron.__version__ which
  - Respects the current version on disk, rather than at last package install for editable installs
  - For editable installs, includes a local version containing:
    - 'editable', identifying it was an editable install
    - the git short hash if available, separated by .
    - '.dirty' if git is available and the git repository is in a dirty state
- Version numbers embedded in saved files use the public version only, so file saving/loading is consitent in editable vs not editable installs  

Closes #46

This results in `polychron --version` results such as:

- `PolyChron 0.2.0` if not editable
- `PolyChron 0.2.0+editable` if editable and `git` is not installed
- `PolyChron 0.2.0+editable.abcdefg` if editable with `git` installed
- `PolyChron 0.2.0` if installed from a wheel (i.e. from pypi in the future). editable installs are not supported in this case.