### PR TITLE
CI: Deploy docs to github pages via upload-pages-artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,3 +48,26 @@ jobs:
       - name: Run mkdocs build
         run: |
           python3 -m mkdocs build
+
+      # Store the compiled use for deployment in the subequent job (if appropriate)
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site/
+
+  # If this build was triggered by a push or workflow_dispatch agianst main, deploy the previously built docs to github pages via an action.
+  deploy:
+    if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'push' ) && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    needs: build-docs
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ PolyChron is prototype software required to be installed locally on a user’s m
 In addition, it allows the user to obtain graph theoretic representations
 of their stratigraphic sequences and prior knowledge within a given hierarchical Bayesian chronological model and save the raw digital data (as collected on-site) along with graph theoretic representations of their models, resulting outputs and supplementary notes produced during such modelling on their machine, thus facilitating future archiving of a complete site archive.
 
+## Documentation
+
+For full documentation including a userguide and developer reference, please see [bryonymoody.github.io/PolyChron](https://bryonymoody.github.io/PolyChron)
 
 ## Installation
 

--- a/docs/assets/css/polychron.css
+++ b/docs/assets/css/polychron.css
@@ -14,8 +14,8 @@
 /* Set custom colours for the slate (i.e. dark) theme.
    see https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/assets/stylesheets/main/_colors.scss */
 [data-md-color-scheme="slate"] {
-    --md-primary-fg-color: var(--polychron-orange);
-    --md-accent-fg-color: var(--polychron-blue);
+    --md-primary-fg-color: var(--polychron-blue);
+    --md-accent-fg-color: var(--polychron-orange);
 }
 
 

--- a/docs/userguide/configuration.md
+++ b/docs/userguide/configuration.md
@@ -1,0 +1,26 @@
+
+# Configuration
+
+PolyChron can be configured through an **optional** `yaml` file, stored in an appropriate location for your operating system.
+
+- Linux: `$XDG_CONFIG_HOME/polychron/config.yaml`
+    - Or `$HOME/.config/polychron/config.yaml` if `XDG_CONFIG_HOME` is not set
+- Windows: `%LOCALAPPDATA%/polychron/config.yaml`
+<!-- - MacOs: @todo -->
+
+For example: 
+
+```yaml
+projects_directory: $HOME/Documents/polychron/projects
+verbose: false
+geometry: "1920x1080"
+```
+
+
+The following configuration options are available:
+
+| name | type | description | 
+|-----|-----|-----|
+| `projects_directory` | `string` | The location of the polychron projects directory on disk, which defaults to `~/Documents/polychron/projects` | 
+| `verbose` | `bool` | If verbose output should be printed by polychron | 
+| `geometry` | `string` | The initial window geometry for the main polychron window, in the form `<width>x<height>` |

--- a/docs/userguide/index.md
+++ b/docs/userguide/index.md
@@ -36,7 +36,7 @@ For more information, use the `-h` or `--help` options
 $ polychron --help
 ```
 
-There are 4 main sections when using PolyChron.
+Once launched, there are there are 4 main sections when using PolyChron.
 
 ```mermaid
 graph LR
@@ -51,21 +51,3 @@ graph LR
 
 >[!WARNING]
 > @todo -  improve the user guide with additional sections
-
-### Configuration
-
-PolyChron can be configured through a yaml file, stored in an appropriate location for your operating system.
-
-- Linux: `$XDG_CONFIG_HOME/polychron/config.yaml`
-    - Or `$HOME/.config/polychron/config.yaml` if `XDG_CONFIG_HOME` is not set
-- Windows: `%LOCALAPPDATA%/polychron/config.yaml`
-<!-- - MacOs: @todo -->
-
-This can be used to control several configuration options, such as the location of the polychron projects directory, which otherwise defaults to `polychron/projects` within your `Documents` directory.
-
-```yaml
-projects_directory: $HOME/Documents/polychron/projects
-```
-
-> [!WARNING]
-> @todo - fully document the configuration options.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,6 @@ theme:
   features:
     - content.code.copy
     - navigation.indexes 
-    - navigation.expand
 
   palette:
     # Palette toggle for automatic mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,9 @@ extra_css:
 theme:
   name: "material"
   locale: en
-  logo: assets/img/logo.png
+  icon:
+    logo: material/graph
+  # logo: assets/img/logo.png
   features:
     - content.code.copy
     - navigation.indexes 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
   - About: index.md
   - User Guide:
     - userguide/index.md
+    - userguide/configuration.md
   - Developer Reference: reference/
 
 extra:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
 ]
 
 [project.urls]
-# Documentation = "https://bryonymoody.github.io/PolyChron"
+Documentation = "https://bryonymoody.github.io/PolyChron"
 Repository = "https://github.com/bryonymoody/PolyChron"
 Issues = "https://github.com/bryonymoody/PolyChron/issues"
 

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -1147,7 +1147,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Parameters:
             context_u: the source of the relationship to be removed
-            contxt_v: the destination of the context to be removed
+            context_v: the destination of the context to be removed
 
         Returns:
             An optional string of the reason the context was removed

--- a/src/polychron/views/FrameView.py
+++ b/src/polychron/views/FrameView.py
@@ -94,7 +94,7 @@ class FrameView(tk.Frame):
         Parameters:
             title: The message box title
             message: The error message
-            args*: Other positional arugments forwarded to the underlyin tkinter call
+            *args: Other positional arguments forwarded to the underlying tkinter call
             icon: The icon to display in the dialog
             **options: other arguments forwarded to `tkinter.messagebox.askquestion`, excluding `parent`
 
@@ -119,7 +119,7 @@ class FrameView(tk.Frame):
         Parameters:
             title: The message box title
             message: The error message
-            args*: Other positional arugments forwarded to the underlyin tkinter call
+            *args: Other positional arguments forwarded to the underlying tkinter call
             icon: The icon to display in the dialog
             **options: other arguments forwarded to `tkinter.messagebox.askokcancel`, excluding `parent`
 
@@ -144,7 +144,7 @@ class FrameView(tk.Frame):
         Parameters:
             title: The message box title
             message: The error message
-            args*: Other positional arugments forwarded to the underlyin tkinter call
+            *args: Other positional arguments forwarded to the underlying tkinter call
             icon: The icon to display in the dialog
             **options: other arguments forwarded to `tkinter.messagebox.askyesno`, excluding `parent`
 
@@ -169,7 +169,7 @@ class FrameView(tk.Frame):
         Parameters:
             title: The message box title
             message: The error message
-            args*: Other positional arugments forwarded to the underlyin tkinter call
+            *args: Other positional arguments forwarded to the underlying tkinter call
             icon: The icon to display in the dialog
             **options: other arguments forwarded to `tkinter.messagebox.askyesnocancel`, excluding `parent`
 


### PR DESCRIPTION
Deploys the mkdocs documentation website to github-pages, when triggered by pushess to `main`, or manually by `workflow-dispatch` events. 

This will require a change in the [pages repository settings](https://github.com/ptheywood/PolyChron/settings/pages), for the source to be `GitHub Actions`
![image](https://github.com/user-attachments/assets/7c804d87-986b-408c-9104-1b863a159f75)

When merged and the setting is changed, the content would be made available at `bryonymoody.github.io/PolyChron`

It may be worth waiting until the documentation is more complete prior to merging / online publication.

Closes #36 