### PR TITLE
Readme: Fix incorrect logo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PolyChron
 
-![PolyChron Logo](./PolyChron/logo.png)
+![PolyChron Logo](./src/polychron/logo.png)
 
 PolyChron is prototype software required to be installed locally on a user’s machine, allowing users to produce multiple chronological models.
 


### PR DESCRIPTION
Fixes logo path in the readme, which I had failed to updated in #65