### PR TITLE
Use a Generic & TypeVar `ViewT` for the `Frame/PopupPresenter.view`

### DIFF
--- a/src/polychron/presenters/AddContextPresenter.py
+++ b/src/polychron/presenters/AddContextPresenter.py
@@ -5,7 +5,7 @@ from ..views.AddContextView import AddContextView
 from .PopupPresenter import PopupPresenter
 
 
-class AddContextPresenter(PopupPresenter[Dict[str, Optional[str]]]):
+class AddContextPresenter(PopupPresenter[AddContextView, Dict[str, Optional[str]]]):
     """Presenter for adding an additional context to the current model
 
     Formerly `popupWindow`

--- a/src/polychron/presenters/CalibrateModelSelectPresenter.py
+++ b/src/polychron/presenters/CalibrateModelSelectPresenter.py
@@ -4,7 +4,7 @@ from ..views.CalibrateModelSelectView import CalibrateModelSelectView
 from .PopupPresenter import PopupPresenter
 
 
-class CalibrateModelSelectPresenter(PopupPresenter[ProjectSelection]):
+class CalibrateModelSelectPresenter(PopupPresenter[CalibrateModelSelectView, ProjectSelection]):
     """Presenter for selecting which models to calibrate, when multiple models are to be calibrated at once.
 
     Formerly `popupWindow8`, used from "tool > Calibrate multiple projects from project"

--- a/src/polychron/presenters/DatafilePreviewPresenter.py
+++ b/src/polychron/presenters/DatafilePreviewPresenter.py
@@ -5,7 +5,7 @@ from ..views.DatafilePreviewView import DatafilePreviewView
 from .PopupPresenter import PopupPresenter
 
 
-class DatafilePreviewPresenter(PopupPresenter[Dict[str, Any]]):
+class DatafilePreviewPresenter(PopupPresenter[DatafilePreviewView, Dict[str, Any]]):
     """Presenter for selecting which models to calibrate, when multiple models are to be calibrated at once.
 
     Formerly `popupWindow7`, used when opening a csv-like file

--- a/src/polychron/presenters/DatingResultsPresenter.py
+++ b/src/polychron/presenters/DatingResultsPresenter.py
@@ -15,7 +15,7 @@ from ..views.DatingResultsView import DatingResultsView
 from .FramePresenter import FramePresenter
 
 
-class DatingResultsPresenter(FramePresenter[ProjectSelection]):
+class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]):
     """Presenter for the Dating Results page/tab."""
 
     def __init__(self, mediator: Mediator, view: DatingResultsView, model: ProjectSelection):

--- a/src/polychron/presenters/FramePresenter.py
+++ b/src/polychron/presenters/FramePresenter.py
@@ -4,29 +4,31 @@ from typing import Any, Generic, Optional, TypeVar
 from ..interfaces import Mediator
 from ..views.FrameView import FrameView
 
-# TypeVar allowing for the Type of the model to be overidden.
-T = TypeVar("T", bound=Any)
+# TypeVar allowing for Generic view types, which should derive from FrameView
+ViewT = TypeVar("ViewT", bound=FrameView)
+# TypeVar allowing for Generic model types
+ModelT = TypeVar("ModelT", bound=Any)
 
 
-class FramePresenter(ABC, Generic[T]):
+class FramePresenter(ABC, Generic[ViewT, ModelT]):
     """Abstract Base Class for Presenters for views which are in the main window, which act as the middle man between a veiw and the underlying data structures (model)."""
 
-    def __init__(self, mediator: Mediator, view: type[FrameView], model: T) -> None:
+    def __init__(self, mediator: Mediator, view: ViewT, model: ModelT) -> None:
         """Initialise the presenter
 
         Args:
             mediator (Mediator): an object which implements the Mediator protocol, i.e. the MainApp
-            view (type[FrameView]): The frame view instance to be presented
-            model (T): The MVP model object which includes the data to be presented and methods to manipulate it
+            view (ViewT): The frame view instance to be presented
+            model (ModelT): The MVP model object which includes the data to be presented and methods to manipulate it
         """
 
         self.mediator: Mediator = mediator
         """Reference to the parent mediator class, to enable switching between presenters/views"""
 
-        self.view: type[FrameView] = view
+        self.view: ViewT = view
         """View managed by this presenter"""
 
-        self.model: T = model
+        self.model: ModelT = model
         """Model objects which include data and buisness logic which are presented by this presenter/view"""
 
     @abstractmethod

--- a/src/polychron/presenters/MCMCProgressPresenter.py
+++ b/src/polychron/presenters/MCMCProgressPresenter.py
@@ -29,7 +29,7 @@ class StdoutRedirector(object):
         pass
 
 
-class MCMCProgressPresenter(PopupPresenter[Model]):
+class MCMCProgressPresenter(PopupPresenter[MCMCProgressView, Model]):
     """Presenter for managing the MCMC progress bar popup view.
 
     When MCMC calibration has completed, and the popup closes, change to the DatingResults tab

--- a/src/polychron/presenters/ManageGroupRelationshipsPresenter.py
+++ b/src/polychron/presenters/ManageGroupRelationshipsPresenter.py
@@ -13,7 +13,7 @@ from ..views.ManageGroupRelationshipsView import ManageGroupRelationshipsView
 from .PopupPresenter import PopupPresenter
 
 
-class ManageGroupRelationshipsPresenter(PopupPresenter[Model]):
+class ManageGroupRelationshipsPresenter(PopupPresenter[ManageGroupRelationshipsView ,Model]):
     """Presenter for managing Residual vs Intrusive contexts"""
 
     def __init__(self, mediator: Mediator, view: ManageGroupRelationshipsView, model: Model) -> None:

--- a/src/polychron/presenters/ManageIntrusiveOrResidualContextsPresenter.py
+++ b/src/polychron/presenters/ManageIntrusiveOrResidualContextsPresenter.py
@@ -6,7 +6,7 @@ from .ManageGroupRelationshipsPresenter import ManageGroupRelationshipsPresenter
 from .PopupPresenter import PopupPresenter
 
 
-class ManageIntrusiveOrResidualContextsPresenter(PopupPresenter[Model]):
+class ManageIntrusiveOrResidualContextsPresenter(PopupPresenter[ManageIntrusiveOrResidualContextsView, Model]):
     """Presenter for managing the MCMC progress bar popup view.
 
     When MCMC calibration has completed, and the popup closes, the DatingResults tab should be loaded

--- a/src/polychron/presenters/ModelCreatePresenter.py
+++ b/src/polychron/presenters/ModelCreatePresenter.py
@@ -7,7 +7,7 @@ from ..views.ModelCreateView import ModelCreateView
 from .FramePresenter import FramePresenter
 
 
-class ModelCreatePresenter(FramePresenter[ProjectSelection]):
+class ModelCreatePresenter(FramePresenter[ModelCreateView, ProjectSelection]):
     def __init__(self, mediator: Mediator, view: ModelCreateView, model: ProjectSelection) -> None:
         # Call the parent class' consturctor
         super().__init__(mediator, view, model)

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -34,7 +34,7 @@ from .ManageGroupRelationshipsPresenter import ManageGroupRelationshipsPresenter
 from .ProjectSelectProcessPopupPresenter import ProjectSelectProcessPopupPresenter
 
 
-class ModelPresenter(FramePresenter[ProjectSelection]):
+class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     """Presenter for the main model tab"""
 
     def __init__(self, mediator: Mediator, view: ModelView, model: ProjectSelection) -> None:

--- a/src/polychron/presenters/ModelSelectPresenter.py
+++ b/src/polychron/presenters/ModelSelectPresenter.py
@@ -7,7 +7,7 @@ from ..views.ModelSelectView import ModelSelectView
 from .FramePresenter import FramePresenter
 
 
-class ModelSelectPresenter(FramePresenter[ProjectSelection]):
+class ModelSelectPresenter(FramePresenter[ModelSelectView, ProjectSelection]):
     """Presenter for a frame allowing the user to select a model from a list of models within a project, or a button to create a new one."""
 
     def __init__(self, mediator: Mediator, view: ModelSelectView, model: ProjectSelection) -> None:

--- a/src/polychron/presenters/PopupPresenter.py
+++ b/src/polychron/presenters/PopupPresenter.py
@@ -4,29 +4,31 @@ from typing import Any, Generic, Optional, TypeVar
 from ..interfaces import Mediator
 from ..views.PopupView import PopupView
 
-# TypeVar allowing for the Type of the model to be overidden.
-T = TypeVar("T", bound=Any)
+# TypeVar allowing for Generic view types, which should derive from PopupView
+ViewT = TypeVar("ViewT", bound=PopupView)
+# TypeVar allowing for Generic model types
+ModelT = TypeVar("ModelT", bound=Any)
 
 
-class PopupPresenter(ABC, Generic[T]):
+class PopupPresenter(ABC, Generic[ViewT, ModelT]):
     """Abstract Base Class for Presenters for views which are in the main window, which act as the middle man between a veiw and the underlying data structures (model)."""
 
-    def __init__(self, mediator: Mediator, view: type[PopupView], model: T) -> None:
+    def __init__(self, mediator: Mediator, view: ViewT, model: ModelT) -> None:
         """Initialise the presenter
 
         Args:
             mediator (Mediator): An object which implements the Mediator protocol
-            view (type[PopupView]): The popup view instance to be presented
-            model (T): The MVP model object which includes the data to be presented and methods to manipulate it
+            view (ViewT): The popup view instance to be presented
+            model (ModelT): The MVP model object which includes the data to be presented and methods to manipulate it
         """
 
         self.mediator: Mediator = mediator
         """Reference to the parent mediator class, to enable switching between presenters/views"""
 
-        self.view: type[PopupView] = view
+        self.view: ViewT = view
         """View managed by this presenter"""
 
-        self.model: T = model
+        self.model: ModelT = model
         """The MVP model object which includes the data to be presented and methods to manipulate it"""
 
         # Bind keyboard shortcuts for the popup window

--- a/src/polychron/presenters/ProjectCreatePresenter.py
+++ b/src/polychron/presenters/ProjectCreatePresenter.py
@@ -6,7 +6,7 @@ from ..views.ProjectCreateView import ProjectCreateView
 from .FramePresenter import FramePresenter
 
 
-class ProjectCreatePresenter(FramePresenter[ProjectSelection]):
+class ProjectCreatePresenter(FramePresenter[ProjectCreateView, ProjectSelection]):
     def __init__(self, mediator: Mediator, view: ProjectCreateView, model: ProjectSelection) -> None:
         # Call the parent class' consturctor
         super().__init__(mediator, view, model)

--- a/src/polychron/presenters/ProjectSelectPresenter.py
+++ b/src/polychron/presenters/ProjectSelectPresenter.py
@@ -6,7 +6,7 @@ from ..views.ProjectSelectView import ProjectSelectView
 from .FramePresenter import FramePresenter
 
 
-class ProjectSelectPresenter(FramePresenter[ProjectSelection]):
+class ProjectSelectPresenter(FramePresenter[ProjectSelectView, ProjectSelection]):
     def __init__(self, mediator: Mediator, view: ProjectSelectView, model: ProjectSelection) -> None:
         # Call the parent class' consturctor
         super().__init__(mediator, view, model)

--- a/src/polychron/presenters/ProjectSelectProcessPopupPresenter.py
+++ b/src/polychron/presenters/ProjectSelectProcessPopupPresenter.py
@@ -17,7 +17,7 @@ from .ProjectSelectPresenter import ProjectSelectPresenter
 from .ProjectWelcomePresenter import ProjectWelcomePresenter
 
 
-class ProjectSelectProcessPopupPresenter(PopupPresenter[ProjectSelection], Mediator):
+class ProjectSelectProcessPopupPresenter(PopupPresenter[ProjectSelectProcessPopupView, ProjectSelection], Mediator):
     """Presenter for the project new or select process, which is a mult-frame presenter, much like the main window."""
 
     def __init__(self, mediator: Mediator, view: ProjectSelectProcessPopupView, model: ProjectSelection) -> None:

--- a/src/polychron/presenters/ProjectWelcomePresenter.py
+++ b/src/polychron/presenters/ProjectWelcomePresenter.py
@@ -4,7 +4,7 @@ from ..views.ProjectWelcomeView import ProjectWelcomeView
 from .FramePresenter import FramePresenter
 
 
-class ProjectWelcomePresenter(FramePresenter[ProjectSelection]):
+class ProjectWelcomePresenter(FramePresenter[ProjectWelcomeView, ProjectSelection]):
     def __init__(self, mediator: Mediator, view: ProjectWelcomeView, model: ProjectSelection) -> None:
         # Call the parent class' consturctor
         super().__init__(mediator, view, model)

--- a/src/polychron/presenters/RemoveContextPresenter.py
+++ b/src/polychron/presenters/RemoveContextPresenter.py
@@ -5,7 +5,7 @@ from ..views.RemoveContextView import RemoveContextView
 from .PopupPresenter import PopupPresenter
 
 
-class RemoveContextPresenter(PopupPresenter[Dict[str, Optional[str]]]):
+class RemoveContextPresenter(PopupPresenter[RemoveContextView, Dict[str, Optional[str]]]):
     """Presenter for a popup window to input the reason for the removal of a node/context
 
     Formerly `popupWindow5`, called by StartPage.node_del_popup, triggered when "Delete context" is selected on a node

--- a/src/polychron/presenters/RemoveStratigraphicRelationshipPresenter.py
+++ b/src/polychron/presenters/RemoveStratigraphicRelationshipPresenter.py
@@ -5,7 +5,9 @@ from ..views.RemoveStratigraphicRelationshipView import RemoveStratigraphicRelat
 from .PopupPresenter import PopupPresenter
 
 
-class RemoveStratigraphicRelationshipPresenter(PopupPresenter[Dict[str, Optional[str]]]):
+class RemoveStratigraphicRelationshipPresenter(
+    PopupPresenter[RemoveStratigraphicRelationshipView, Dict[str, Optional[str]]]
+):
     """Presenter for a popup window to provide the reason for the removal of a single stratigraphic relationship
 
     Formerly `popupWindow6`, called by StartPage.edge_del_popup, triggered when "Delete stratigraphic relationship" is selected on an edge

--- a/src/polychron/presenters/ResidualOrIntrusivePresenter.py
+++ b/src/polychron/presenters/ResidualOrIntrusivePresenter.py
@@ -13,7 +13,7 @@ from ..views.ResidualOrIntrusiveView import ResidualOrIntrusiveView
 from .PopupPresenter import PopupPresenter
 
 
-class ResidualOrIntrusivePresenter(PopupPresenter[Model], Mediator):
+class ResidualOrIntrusivePresenter(PopupPresenter[ResidualOrIntrusiveView, Model], Mediator):
     """Presenter for managing the MCMC progress bar popup view.
 
     When MCMC calibration has completed, and the popup closes, the mediator should change to the DatingResults tab

--- a/src/polychron/presenters/SplashPresenter.py
+++ b/src/polychron/presenters/SplashPresenter.py
@@ -8,7 +8,7 @@ from .FramePresenter import FramePresenter
 from .ProjectSelectProcessPopupPresenter import ProjectSelectProcessPopupPresenter
 
 
-class SplashPresenter(FramePresenter[ProjectSelection]):
+class SplashPresenter(FramePresenter[SplashView, ProjectSelection]):
     """Presenter for the Splash Frame, shown in the main view before a project has been loaded.
 
     This exists soley to allow users who close the initial project selection page to re-open it.


### PR DESCRIPTION
This allows editors to suggest view-specific methods and properties when implementing presenters (which are tightly coupled with the View they present)

Also renames the Model Typevar `T` to `ModelT`

Closes #91