### PR TITLE
Replace Optional with python3.10+ '| None' via __future__

### DIFF
--- a/src/polychron/GUIApp.py
+++ b/src/polychron/GUIApp.py
@@ -1,11 +1,13 @@
 """The main GUI App class, which initialises the GUI application and can be used to run the main render loop"""
 
+from __future__ import annotations
+
 import re
 import tkinter as tk
 import tkinter.font as tkFont
 from importlib.metadata import version
 from tkinter import ttk
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from ttkthemes import ThemedStyle, ThemedTk
 
@@ -68,7 +70,7 @@ class GUIApp(Mediator):
         self.project_selector_obj: ProjectSelection = ProjectSelection(self.config.projects_directory)
 
         # Construct the views and presenters for main window views (i.e. not-popups)
-        self.current_presenter_key: Optional[str] = None
+        self.current_presenter_key: str | None = None
         self.presenters: Dict[str, FramePresenter] = {
             "Splash": SplashPresenter(self, SplashView(self.container), self.project_selector_obj),
             "Model": ModelPresenter(self, ModelView(self.container), self.project_selector_obj),
@@ -81,7 +83,7 @@ class GUIApp(Mediator):
             # Immeditely hide the frame, but remember it's settings.
             presenter.view.grid_remove()
 
-    def set_window_title(self, suffix: Optional[str] = None) -> None:
+    def set_window_title(self, suffix: str | None = None) -> None:
         """Update the window title to include Polychron, the version of polychron, and the optional suffix
 
         Parameters:
@@ -92,7 +94,7 @@ class GUIApp(Mediator):
             title += f" | {suffix}"
         self.root.title(title)
 
-    def get_presenter(self, key: Optional[str]) -> Optional[FramePresenter]:
+    def get_presenter(self, key: str | None) -> FramePresenter | None:
         """Get a main frame presenter by it's name.
 
         Parameters:
@@ -106,7 +108,7 @@ class GUIApp(Mediator):
         else:
             return None
 
-    def switch_presenter(self, key: Optional[str]) -> None:
+    def switch_presenter(self, key: str | None) -> None:
         """Switch the current presenter using the provided key
 
         Parameters:
@@ -133,7 +135,7 @@ class GUIApp(Mediator):
                 f"Invalid presenter key '{key}' for GUIApp.switch_presenter. Valid values: {list(self.presenters.keys())}"
             )
 
-    def close_window(self, reason: Optional[str] = None) -> None:
+    def close_window(self, reason: str | None = None) -> None:
         self.exit_application()
 
     def register_global_keybinds(self) -> None:
@@ -147,7 +149,7 @@ class GUIApp(Mediator):
         """Register protocols with the root window - i.e. what to do on (graceful) application exit"""
         self.root.protocol("WM_DELETE_WINDOW", self.exit_application)
 
-    def save_current_model(self, event: Optional[Any] = None) -> None:
+    def save_current_model(self, event: Any | None = None) -> None:
         """If a model is currently open, save it"""
         if (
             self.current_presenter_key == "Model"
@@ -159,7 +161,7 @@ class GUIApp(Mediator):
             if model is not None:
                 model.save()
 
-    def exit_application(self, event: Optional[Any] = None) -> None:
+    def exit_application(self, event: Any | None = None) -> None:
         """Callback function for graceful application exit via keybind or window manager close."""
         # Quit the root window
         self.root.quit()
@@ -182,7 +184,7 @@ class GUIApp(Mediator):
             # Apply the new window geometry
             self.root.geometry(new_geometry)
 
-    def launch(self, project_name: Optional[str] = None, model_name: Optional[str] = None) -> None:
+    def launch(self, project_name: str | None = None, model_name: str | None = None) -> None:
         """Method to launch the GUIApp, i.e. start the render loop
 
         Parameters:

--- a/src/polychron/interfaces.py
+++ b/src/polychron/interfaces.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Optional, Protocol, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, Union
 
 # Avoid circular dependencies but provide type hints
 if TYPE_CHECKING:
@@ -11,14 +13,14 @@ class Mediator(Protocol):
 
     This avoids a circular dependency between the GUIApp and presenters."""
 
-    def switch_presenter(self, key: Optional[str]) -> None:
+    def switch_presenter(self, key: str | None) -> None:
         """Switch the active presenter & view by string key.
 
         Parameters:
             key: The key of the presenter to switch to"""
         ...
 
-    def get_presenter(self, key: Optional[str]) -> Optional[Union["FramePresenter", "PopupPresenter"]]:
+    def get_presenter(self, key: str | None) -> Union["FramePresenter", "PopupPresenter"] | None:
         """Get a presenter by it's Key, if it valid
 
         Parameters:
@@ -29,7 +31,7 @@ class Mediator(Protocol):
         """
         ...
 
-    def close_window(self, reason: Optional[str] = None) -> None:
+    def close_window(self, reason: str | None = None) -> None:
         """Gracefully close any windows this meadiator is in charge of.
 
         Parameters:

--- a/src/polychron/models/InterpolatedRCDCalibrationCurve.py
+++ b/src/polychron/models/InterpolatedRCDCalibrationCurve.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import importlib.resources
 import pathlib
 from dataclasses import dataclass, field
-from typing import Optional
 
 import pandas as pd
 
@@ -25,7 +26,7 @@ class InterpolatedRCDCalibrationCurve:
     )
     """Path to calibration data on disk. Defaults to the location of linear_interpolation.txt within the polychron package."""
 
-    __dataframe: Optional[pd.DataFrame] = field(default=None, init=None)
+    __dataframe: pd.DataFrame | None = field(default=None, init=None)
     """Dataframe containing the parsed calibrationd data"""
 
     def load(self) -> None:

--- a/src/polychron/models/MCMCData.py
+++ b/src/polychron/models/MCMCData.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import json
 import pathlib
 from dataclasses import dataclass, field
 from importlib.metadata import version
-from typing import Any, Dict, List, Optional, Tuple, get_type_hints
+from typing import Any, Dict, List, Tuple, get_type_hints
 
 import pandas as pd
 
@@ -29,7 +31,7 @@ class MCMCData:
     Formerly `StartPage.ACCEPT`
     """
 
-    accept_samples_phi: Optional[Any] = field(default=None)
+    accept_samples_phi: Any | None = field(default=None)
     """Accepted group boundaries from MCMC simulation
     
     Formerly `StartPage.PHI_ACCEPT`
@@ -47,7 +49,7 @@ class MCMCData:
     Formerly `StartPage.P`
     """
 
-    all_samples_context: Optional[List[List[float]]] = field(default=None)
+    all_samples_context: List[List[float]] | None = field(default=None)
     """A list of lists containing all samples for contexts from MCMC, including rejected samples. 
 
     I.e. accept_samples_context is a subset of this.
@@ -55,7 +57,7 @@ class MCMCData:
     Formerly `StartPage.ALL_SAMPS_CONT`
     """
 
-    all_samples_phi: Optional[List[List[float]]] = field(default=None)
+    all_samples_phi: List[List[float]] | None = field(default=None)
     """A list of lists, containing all samples for group boundaries from MCMC, including rejected samples.
 
     I.e. accept_samples_phi is a subset of this.
@@ -203,9 +205,9 @@ class MCMCData:
                     type_hint = cls_type_hints[k]
                     if mcmc_data[k] is None:
                         pass
-                    elif type_hint in [pathlib.Path, Optional[pathlib.Path]]:
+                    elif type_hint in [pathlib.Path, pathlib.Path | None]:
                         mcmc_data[k] = pathlib.Path(mcmc_data[k])
-                    elif type_hint in [Optional[List[Tuple[str, str]]]]:
+                    elif type_hint in [List[Tuple[str, str]] | None]:
                         # tuples are stored as lists in json, so must convert from a list of lists to a list of tuples
                         mcmc_data[k] = [tuple(sub) for sub in mcmc_data[k]]
                 else:

--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -10,7 +10,7 @@ import sys
 from dataclasses import dataclass, field
 from importlib.metadata import version
 from inspect import signature
-from typing import Any, Dict, List, Literal, Optional, Tuple, get_type_hints
+from typing import Any, Dict, List, Literal, Tuple, get_type_hints
 
 import networkx as nx
 import pandas as pd
@@ -38,41 +38,41 @@ class Model:
     """The path to the directory representing this model on disk
     """
 
-    stratigraphic_graphviz_file: Optional[pathlib.Path] = field(default=None)
+    stratigraphic_graphviz_file: pathlib.Path | None = field(default=None)
     """Stratigraphic path for .dot/.gv input
     
     Formerly StartPage.FILE_INPUT
     """
 
-    stratigraphic_df: Optional[pd.DataFrame] = field(default=None)
+    stratigraphic_df: pd.DataFrame | None = field(default=None)
     """The stratigraphic file from CSV, if loaded.
 
     Formerly `StartPage.stratfile`
     """
 
-    stratigraphic_dag: Optional[nx.DiGraph] = field(default=None)
+    stratigraphic_dag: nx.DiGraph | None = field(default=None)
     """Stratigraphic Directed Acyclic Graph, initially produced from the stratigraphic dataframe or graphviz file before being mutated.
     
     Formerly `StartPage.graph`
     """
 
-    stratigraphic_image: Optional[Image.Image] = field(default=None)
+    stratigraphic_image: Image.Image | None = field(default=None)
     """Rendered version of the stratigraphic graph as an image, for whicle a handle must be kept for persistence.
     """
 
-    radiocarbon_df: Optional[pd.DataFrame] = field(default=None)
+    radiocarbon_df: pd.DataFrame | None = field(default=None)
     """Dataframe containing radiocarbon dating information, loaded from disk
     
     Formerly `StartPage.datefile`
     """
 
-    context_no_unordered: Optional[List[str]] = field(default=None)
+    context_no_unordered: List[str] | None = field(default=None)
     """A list of stratigraphic graph nodes, initially populated within open_scientific_dating_file before being used elsewhere.
 
     This list is in the order from the input file, rather than a topological order.
     """
 
-    group_df: Optional[pd.DataFrame] = field(default=None)
+    group_df: pd.DataFrame | None = field(default=None)
     """Dataframe of context grouping information loaded from disk. 
 
     Expected columns ["context", "Group"]
@@ -80,7 +80,7 @@ class Model:
     Formerly `StartPage.phasefile`
     """
 
-    group_relationship_df: Optional[pd.DataFrame] = field(default=None)
+    group_relationship_df: pd.DataFrame | None = field(default=None)
     """Dataframe containing group relationship information loaded from disk
     
     Expected columns ["above", "below"], although order of columns is used not the column names
@@ -88,13 +88,13 @@ class Model:
     Formerly `phase_rel_df` in `StartPage.open_file5`
     """
 
-    group_relationships: Optional[List[Tuple[str, str]]] = field(default=None)
+    group_relationships: List[Tuple[str, str]] | None = field(default=None)
     """A list of the relative relationships between groups, stored as Tuples of (above, below))
 
     Formerly `StartPage.phase_rels`
     """
 
-    context_equality_df: Optional[pd.DataFrame] = field(default=None)
+    context_equality_df: pd.DataFrame | None = field(default=None)
     """Dataframe containing context equality relationship information loaded from disk
     
     Formerly `equal_rel_df` in `StartPage.open_file6`
@@ -106,13 +106,13 @@ class Model:
     Formerly `global load_check`, where "loaded" is now True and "not_loaded" is False.
     """
 
-    chronological_dag: Optional[nx.DiGraph] = field(default=None)
+    chronological_dag: nx.DiGraph | None = field(default=None)
     """Chronological directed graph, produced by rendering the chronological graph
     
     Formerly `StartPage.chrono_dag`
     """
 
-    chronological_image: Optional[Image.Image] = field(default=None)
+    chronological_image: Image.Image | None = field(default=None)
     """Rendered version of the Chronological graph as an image, for which a handle must be kept for persistence and to avoid regenerating when not required.
 
     When load_check is True, this image is valid for the current state of the Model.
@@ -144,7 +144,7 @@ class Model:
     Formerly `StartPage.edges_del` and `StartPage.deledges_meta`
     """
 
-    resid_or_intru_dag: Optional[nx.DiGraph] = field(default=None)
+    resid_or_intru_dag: nx.DiGraph | None = field(default=None)
     """Copy of stratigraphic_dag for the residual or intrusive workflow
 
     This is mutated to show which nodes have been marked as residual or intrusive.
@@ -154,7 +154,7 @@ class Model:
     Formerly `PageTwo.graphcopy`
     """
 
-    resid_or_intru_image: Optional[Image.Image] = field(default=None)
+    resid_or_intru_image: Image.Image | None = field(default=None)
     """Image handle for the rendered png of the stratigraphic graph with residual or intrusive node highlighting.
 
     A handle to this needs to be maintained to avoid garbage collection
@@ -232,7 +232,7 @@ class Model:
     If mcmc_check is true, it is implied that this has been saved to disk
     """
 
-    node_coords_and_scale: Optional[Tuple[pd.DataFrame, List[float]]] = field(default=None)
+    node_coords_and_scale: Tuple[pd.DataFrame, List[float]] | None = field(default=None)
     """A tuple containing a dataframe of node coordinates within the most recently rendered svg graph, and a list of 2 floating point numbers which are from svg scale properties.
 
     Set and used for node right-click detection
@@ -242,7 +242,7 @@ class Model:
     Formerly `global node_df`
     """
 
-    __calibration: Optional[InterpolatedRCDCalibrationCurve] = field(default=None, init=False, repr=False)
+    __calibration: InterpolatedRCDCalibrationCurve | None = field(default=None, init=False, repr=False)
     """Interpolated RCD calibration curve object, which is storedin a member variable so it is loaded once and only once"""
 
     def get_working_directory(self) -> pathlib.Path:
@@ -456,18 +456,18 @@ class Model:
                     # If the values is None, do nothing.
                     if model_data[k] is None:
                         pass
-                    elif type_hint in [pathlib.Path, Optional[pathlib.Path]]:
+                    elif type_hint in [pathlib.Path, pathlib.Path | None]:
                         model_data[k] = pathlib.Path(model_data[k])
-                    elif type_hint in [pd.DataFrame, Optional[pd.DataFrame]]:
+                    elif type_hint in [pd.DataFrame, pd.DataFrame | None]:
                         # DataFrames are encoded as json, parsed back into a dictionary before being encoded as json again. At this point, the first json decode has occurred so we should have a dictionary of dictionaries (one per column) which can be reconverted.
                         # However, this may have lost typing information for the columns, but they should have been strings anyway
                         if isinstance(model_data[k], dict):
                             model_data[k] = pd.DataFrame.from_dict(model_data[k], orient="columns")
-                    elif type_hint in [nx.DiGraph, Optional[nx.DiGraph]]:
+                    elif type_hint in [nx.DiGraph, nx.DiGraph | None]:
                         # Convert the node_link_data encoded networkx digraph via node_link_graph
                         # explicitly set edges value to future behaviour for networkx
                         model_data[k] = nx.node_link_graph(model_data[k], edges="edges", multigraph=False)
-                    elif type_hint in [Optional[List[Tuple[str, str]]]]:
+                    elif type_hint in [List[Tuple[str, str]] | None]:
                         # tuples are stored as lists in json, so must convert from a list of lists to a list of tuples
                         model_data[k] = [tuple(sub) for sub in model_data[k]]
                 else:
@@ -791,7 +791,7 @@ class Model:
         if png_path.is_file():
             self.chronological_image = Image.open(png_path)
 
-    def record_deleted_node(self, context: str, reason: Optional[str] = None) -> None:
+    def record_deleted_node(self, context: str, reason: str | None = None) -> None:
         """Method to add a node to the list of deleted nodes
 
         Parameters:
@@ -800,7 +800,7 @@ class Model:
         """
         self.deleted_nodes.append((context, reason))
 
-    def record_deleted_edge(self, context_a: str, context_b: str, reason: Optional[str] = None) -> None:
+    def record_deleted_edge(self, context_a: str, context_b: str, reason: str | None = None) -> None:
         """Method to add an edge to the list of deleted edges
 
         Parameters:

--- a/src/polychron/models/Project.py
+++ b/src/polychron/models/Project.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import copy
 import pathlib
 import shutil
 import sys
 from dataclasses import dataclass, field
-from typing import Optional
 
 from .Model import Model
 
@@ -19,7 +20,7 @@ class Project:
     """The directory representing this project on disk
     """
 
-    models: dict[str, Optional[Model]] = field(default_factory=dict)
+    models: dict[str, Model | None] = field(default_factory=dict)
     """A dictionary of models within this project, with their name as the key"""
 
     def create_dirs(self) -> bool:
@@ -39,19 +40,19 @@ class Project:
         """Cheeck if a model exists within the project."""
         return name in self.models
 
-    def get_model(self, name: str) -> Optional[Model]:
+    def get_model(self, name: str) -> Model | None:
         """Get a model from within the project, loading from disk if it has not yet been loaded"""
         if name in self.models:
             if self.models[name] is None:
                 self.load_model_from_disk(name)
         return self.models.get(name, None)
 
-    def get_or_create_model(self, name: str, other: Optional[Model]) -> Model:
+    def get_or_create_model(self, name: str, other: Model | None) -> Model:
         """Get or create a model within this Project, copying a reference model if provided
 
         Parameters:
             name (str): The name of the model to be fetched or created
-            other (Optional[Model]): An optional model to copy from
+            other (Model | None): An optional model to copy from
 
         Returns:
             The existing or new model with the specified model name
@@ -64,12 +65,12 @@ class Project:
         # If no model was returned, create one and return it.
         return self.create_model(name, other)
 
-    def create_model(self, name: str, other: Optional[Model]) -> Model:
+    def create_model(self, name: str, other: Model | None) -> Model:
         """Create a new model within the project with the provided name , copying a reference model if provided
 
         Parameters:
             name (str): The name of the model to be created
-            other (Optional[Model]): An optional model to copy from
+            other (Model | None): An optional model to copy from
 
         Returns:
             The new Model

--- a/src/polychron/models/ProjectSelection.py
+++ b/src/polychron/models/ProjectSelection.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import os
 import pathlib
-from typing import Optional
 
 from ..models.Model import Model
 from ..models.Project import Project
@@ -18,18 +19,18 @@ class ProjectSelection:
 
         self.__projects_directory: ProjectsDirectory = ProjectsDirectory(projects_directory_path)
 
-        self.__current_project_name: Optional[str] = None
+        self.__current_project_name: str | None = None
         """The currently selected project within the project directory."""
 
-        self.__current_model_name: Optional[str] = None
+        self.__current_model_name: str | None = None
         """The currently selected model within the currently selected project for this projects directory.
         """
 
-        self.__next_project_name: Optional[str] = None
+        self.__next_project_name: str | None = None
         """The name of the next project to be switched to, which may or may not exist
         """
 
-        self.__next_model_name: Optional[str] = None
+        self.__next_model_name: str | None = None
         """The name of a next model to be switched to, which may or may not exist
         """
 
@@ -55,17 +56,17 @@ class ProjectSelection:
         return self.__projects_directory
 
     @property
-    def current_project_name(self) -> Optional[str]:
+    def current_project_name(self) -> str | None:
         """The name of the currently selected project, which may be None"""
         return self.__current_project_name
 
     @property
-    def current_model_name(self) -> Optional[str]:
+    def current_model_name(self) -> str | None:
         """The name of the currently selected model, which may be None"""
         return self.__current_model_name
 
     @property
-    def current_project(self) -> Optional[Project]:
+    def current_project(self) -> Project | None:
         """Get (a reference) to the currently selected Project object"""
         if self.current_project_name is not None:
             return self.__projects_directory.get_project(self.current_project_name)
@@ -73,7 +74,7 @@ class ProjectSelection:
             return None
 
     @property
-    def current_model(self) -> Optional[Model]:
+    def current_model(self) -> Model | None:
         """Get (a reference) to the currently selected model object"""
         if (project := self.current_project) is not None:
             if self.current_model_name is not None:
@@ -92,17 +93,17 @@ class ProjectSelection:
         self.__current_model_name = name
 
     @property
-    def next_project_name(self) -> Optional[str]:
+    def next_project_name(self) -> str | None:
         """Get the name of the next project to be selected/created, which may be None"""
         return self.__next_project_name
 
     @property
-    def next_model_name(self) -> Optional[str]:
+    def next_model_name(self) -> str | None:
         """Get the name of the next model to be selected/created, which may be None"""
         return self.__next_model_name
 
     @property
-    def next_project(self) -> Optional[Project]:
+    def next_project(self) -> Project | None:
         """Get (a reference) to the "next" Project object, if it already exists"""
         if self.next_project_name is not None:
             return self.__projects_directory.get_project(self.next_project_name)
@@ -110,7 +111,7 @@ class ProjectSelection:
             return None
 
     @property
-    def next_model(self) -> Optional[Model]:
+    def next_model(self) -> Model | None:
         """Get (a reference) to the "next" model object, if it already exists within the next project"""
         if (project := self.next_project) is not None:
             if self.next_model_name is not None:
@@ -119,7 +120,7 @@ class ProjectSelection:
                 return None
 
     @next_project_name.setter
-    def next_project_name(self, name: Optional[str]) -> None:
+    def next_project_name(self, name: str | None) -> None:
         """Set the current project by name
 
         This project may or may not exist yet.
@@ -127,7 +128,7 @@ class ProjectSelection:
         self.__next_project_name = name
 
     @next_model_name.setter
-    def next_model_name(self, name: Optional[str]) -> None:
+    def next_model_name(self, name: str | None) -> None:
         """Set the current model by name
 
         This model may or may not exist yet

--- a/src/polychron/models/ProjectsDirectory.py
+++ b/src/polychron/models/ProjectsDirectory.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import pathlib
 from dataclasses import dataclass, field
-from typing import Optional
 
 from ..models.Project import Project
 
@@ -33,7 +34,7 @@ class ProjectsDirectory:
         """Check if the specified project exists or not"""
         return project_name in self.projects
 
-    def get_project(self, project_name: str) -> Optional[Project]:
+    def get_project(self, project_name: str) -> Project | None:
         """Fetch a project by it's name
 
         Parameters:

--- a/src/polychron/presenters/AddContextPresenter.py
+++ b/src/polychron/presenters/AddContextPresenter.py
@@ -1,17 +1,19 @@
-from typing import Dict, Optional
+from __future__ import annotations
+
+from typing import Dict
 
 from ..interfaces import Mediator
 from ..views.AddContextView import AddContextView
 from .PopupPresenter import PopupPresenter
 
 
-class AddContextPresenter(PopupPresenter[AddContextView, Dict[str, Optional[str]]]):
+class AddContextPresenter(PopupPresenter[AddContextView, Dict[str, str | None]]):
     """Presenter for adding an additional context to the current model
 
     Formerly `popupWindow`
     """
 
-    def __init__(self, mediator: Mediator, view: AddContextView, model: Dict[str, Optional[str]]) -> None:
+    def __init__(self, mediator: Mediator, view: AddContextView, model: Dict[str, str | None]) -> None:
         # Call the parent class' consturctor
         super().__init__(mediator, view, model)
 

--- a/src/polychron/presenters/DatingResultsPresenter.py
+++ b/src/polychron/presenters/DatingResultsPresenter.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from tkinter import simpledialog
-from typing import Any, List, Optional
+from typing import Any, List
 
 import matplotlib as plt
 import networkx as nx
@@ -8,7 +10,6 @@ from matplotlib.figure import Figure
 
 from ..automated_mcmc_ordering_coupling_copy import HPD_interval
 from ..interfaces import Mediator
-from ..models.Model import Model
 from ..models.ProjectSelection import ProjectSelection
 from ..util import node_coords_fromjson, phase_length_finder
 from ..views.DatingResultsView import DatingResultsView
@@ -71,7 +72,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
         # Ensure content is correct when switching tab
         self.chronograph_render_post()
 
-    def get_window_title_suffix(self) -> Optional[str]:
+    def get_window_title_suffix(self) -> str | None:
         return f"{self.model.current_project_name} - {self.model.current_model_name}"
 
     def on_file_save(self) -> None:
@@ -79,7 +80,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
 
         Formerly a call to startpage::save_state_1
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         model_model.save()
@@ -129,7 +130,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
         self.view.unbind_littlecanvas2_callback("<Button-1>")
         self.view.bind_littlecanvas2_callback("<Button-1>", self.on_left)
         # Show the right click menu
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         has_image = model_model.chronological_image is not None
         # Show the test menu, returning the coords it was place at?
         x_scal, y_scal = self.view.show_testmenu(has_image)
@@ -150,7 +151,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
 
         Formerly `PageOne.move_from2`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         if model_model.chronological_image is not None:
@@ -161,7 +162,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
 
         Formerly `PageOne.move_to2`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         if model_model.chronological_image is not None:
@@ -170,7 +171,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
 
     def chronograph_render_post(self) -> None:
         """Formerly `PageOne.chronograph_render_post`"""
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -189,7 +190,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
         """
         node_inside = "no node"
 
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return node_inside
 
@@ -231,7 +232,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
         Formerly `PageOne.get_hpd_interval`
         """
 
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -267,7 +268,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
         Formerly PageOn.node_finder
         """
 
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -302,7 +303,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
             self.results_list.append(self.node)
 
     def testmenu_get_time_elapsed_between(self) -> None:
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None or not model_model.mcmc_check:
             return
 
@@ -359,7 +360,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
         """loads posterior density plots into the graph
 
         Formerly PageOne.mcmc_output"""
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 

--- a/src/polychron/presenters/FramePresenter.py
+++ b/src/polychron/presenters/FramePresenter.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, TypeVar
 
 from ..interfaces import Mediator
 from ..views.FrameView import FrameView
@@ -36,7 +38,7 @@ class FramePresenter(ABC, Generic[ViewT, ModelT]):
         """Update view data for the current state of the model"""
         pass
 
-    def get_window_title_suffix(self) -> Optional[str]:
+    def get_window_title_suffix(self) -> str | None:
         """Get a optional suffix for the window title, for this frame.
 
         Returns:

--- a/src/polychron/presenters/ManageGroupRelationshipsPresenter.py
+++ b/src/polychron/presenters/ManageGroupRelationshipsPresenter.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import copy
-from typing import Any, Optional
+from typing import Any
 
 import networkx as nx
 import numpy as np
@@ -13,7 +15,7 @@ from ..views.ManageGroupRelationshipsView import ManageGroupRelationshipsView
 from .PopupPresenter import PopupPresenter
 
 
-class ManageGroupRelationshipsPresenter(PopupPresenter[ManageGroupRelationshipsView ,Model]):
+class ManageGroupRelationshipsPresenter(PopupPresenter[ManageGroupRelationshipsView, Model]):
     """Presenter for managing Residual vs Intrusive contexts"""
 
     def __init__(self, mediator: Mediator, view: ManageGroupRelationshipsView, model: Model) -> None:
@@ -105,7 +107,7 @@ class ManageGroupRelationshipsPresenter(PopupPresenter[ManageGroupRelationshipsV
     def on_confirm(self) -> None:
         self.get_coords()
 
-    def on_move(self, event: Optional[Any]) -> None:
+    def on_move(self, event: Any) -> None:
         """on move event for dragging boxes around
 
         Formerly `popupWindow3.on_move`
@@ -282,6 +284,6 @@ class ManageGroupRelationshipsPresenter(PopupPresenter[ManageGroupRelationshipsV
         # Close the popup window
         self.close_window()
 
-    def close_window(self, reason: Optional[str] = None) -> None:
+    def close_window(self, reason: str | None = None) -> None:
         # Close the view
         self.view.destroy()

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 import tkinter.messagebox
 from tkinter.filedialog import askopenfile
-from typing import Any, List, Optional
+from typing import Any, List
 
 import networkx as nx
 import numpy as np
@@ -9,7 +9,6 @@ import pandas as pd
 import pydot
 
 from ..interfaces import Mediator
-from ..models.Model import Model
 from ..models.ProjectSelection import ProjectSelection
 from ..presenters.AddContextPresenter import AddContextPresenter
 from ..presenters.CalibrateModelSelectPresenter import CalibrateModelSelectPresenter
@@ -127,7 +126,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     def update_view(self) -> None:
         """Update the view to reflect the current state of the model"""
         # Get the actual model
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -170,7 +169,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
                 [tuple([edge_label(ctx_a, ctx_b), meta]) for ctx_a, ctx_b, meta in model_model.deleted_edges]
             )
 
-    def get_window_title_suffix(self) -> Optional[str]:
+    def get_window_title_suffix(self) -> str | None:
         return f"{self.model.current_project_name} - {self.model.current_model_name}"
 
     def popup_calibrate_model(self) -> None:
@@ -178,7 +177,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Formerly `StartPage.load_mcmc`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         # Create the popup presenter and view
@@ -205,7 +204,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
     def chronograph_render_wrap(self) -> None:
         """wraps chronograph render so we can assign a variable when runing the func using a button"""
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -232,13 +231,13 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
             self.view.clear_littlecanvas2()
             model_model.chronological_dag = self.chronograph_render()
 
-    def chronograph_render(self) -> Optional[nx.DiGraph]:
+    def chronograph_render(self) -> nx.DiGraph | None:
         """initiates residual checking function then renders the graph when thats done
 
         Returns a copy of the produced chronological graph (if requirements met and no error occurs?).
         """
 
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -313,7 +312,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         )
         file = askopenfile(mode="r", filetypes=[("DOT Files", "*.dot"), ("Graphviz Files", "*.gv")])
         if file is not None:
-            model_model: Optional[Model] = self.model.current_model
+            model_model = self.model.current_model
 
             # Store the path, marking that the most rencent input was a .dot/gv file
             model_model.set_stratigraphic_graphviz_file(file.name)
@@ -348,7 +347,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         if file is not None:
             try:
-                model_model: Optional[Model] = self.model.current_model
+                model_model = self.model.current_model
                 df = pd.read_csv(file, dtype=str)
                 load_it = self.file_popup(df)
                 if load_it == "load":
@@ -387,7 +386,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         if file is not None:
             try:
-                model_model: Optional[Model] = self.model.current_model
+                model_model = self.model.current_model
                 df = pd.read_csv(file)
                 df = df.applymap(str)
                 load_it = self.file_popup(df)
@@ -409,7 +408,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         file = askopenfile(mode="r", filetypes=[("CSV Files", "*.csv")])
         if file is not None:
             try:
-                model_model: Optional[Model] = self.model.current_model
+                model_model = self.model.current_model
                 df = pd.read_csv(file)
                 df = df.applymap(str)
                 load_it = self.file_popup(df)
@@ -431,7 +430,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         file = askopenfile(mode="r", filetypes=[("CSV Files", "*.csv")])
         if file is not None:
             try:
-                model_model: Optional[Model] = self.model.current_model
+                model_model = self.model.current_model
                 df = pd.read_csv(file)
                 group_rels = [(str(df["above"][i]), str(df["below"][i])) for i in range(len(df))]
                 load_it = self.file_popup(pd.DataFrame(group_rels, columns=["Younger group", "Older group"]))
@@ -452,7 +451,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         file = askopenfile(mode="r", filetypes=[("CSV Files", "*.csv")])
         if file is not None:
             try:
-                model_model: Optional[Model] = self.model.current_model
+                model_model = self.model.current_model
                 df = pd.read_csv(file)
                 df = df.applymap(str)
                 # Update the model & post process, updating the graph
@@ -482,7 +481,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         """
 
         # Render the strat graph in pahse mode, if there is one to render, updating the model and view
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is not None:
             # Store a flag marking this as being enabled. Should this be model data?
             model_model.grouped_rendering = True
@@ -542,7 +541,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
             self.testmenu_place_above_prep()
 
         # Get the Model object
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         # Update the image in the canvas
@@ -560,7 +559,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     def testmenu_delete_context(self) -> None:
         """Callback function from the testmenu for deleting a single context"""
         # Get the Model object
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -582,7 +581,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     def testmenu_add_new_contexts(self) -> None:
         """Callback function from the testmenu for adding contexts"""
         # Get the Model object
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         if model_model.load_check:
@@ -607,7 +606,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     def testmenu_delete_strat_with(self) -> None:
         """Callback function from the testmenu for deleting stratigrahic relationship edges"""
         # Get the Model object
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -656,7 +655,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     def testmenu_place_above(self) -> None:
         """Callback function from the testmenu for adding stratigrahic relationship"""
         # Get the Model object
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -677,7 +676,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     def testmenu_delete_stratigraphic_prep(self) -> None:
         """Callback function from the testmenu for deleting stratigraphic relationships, adding an option to the menu when a node was selected."""
         # Get the Model object
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -690,7 +689,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     def testmenu_equate_context_with(self) -> None:
         """Callback function from the testmenu to equate two contexts (when one has already been selected)"""
         # Get the Model object
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -722,7 +721,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     def testmenu_equate_context_prep(self) -> None:
         """Callback function from the testmenu which sets up menu to equate context for when user picks next node"""
         # Get the Model object
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         if len(self.comb_nodes) == 1:
@@ -745,7 +744,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     def testmenu_get_supplementary_for_context(self) -> None:
         """Callback function from the testmenu to show supplementary data for the selected context/node"""
         # Get the Model object
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -772,7 +771,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
     def testmenu_place_above_prep(self) -> None:
         """Callback function from the testmenu which sets up for placing one context above another"""
         # Get the Model object
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -809,7 +808,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         self.view.unbind_littlecanvas_callback("<Button-1>")
         self.view.bind_littlecanvas_callback("<Button-1>", self.on_left)
         # Show the right click menu
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         has_image = model_model.stratigraphic_image is not None
         x_scal, y_scal = self.view.show_testmenu(has_image)
         # If the model has a stratigraphic image presented, check if a node has been right clicked on and store in a member variable
@@ -903,7 +902,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         self.view.wait_window(popup_presenter.view)
 
         # Get the new model
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -919,7 +918,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Formerly `StartPage.resize`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
 
@@ -934,7 +933,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Formerly `StartPage.resize2`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         # Re-open the image inside the Model
@@ -948,7 +947,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Formerly `StartPage.move_from`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         if model_model.stratigraphic_image is not None:
@@ -959,7 +958,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Formerly `StartPage.move_to`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         if model_model.stratigraphic_image is not None:
@@ -971,7 +970,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Formerly `StartPage.move_from2`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         if model_model.chronological_image is not None:
@@ -982,7 +981,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Formerly `StartPage.move_to2`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         if model_model.chronological_image is not None:
@@ -1008,7 +1007,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Formerly `StartPage.addedge`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         x_1 = edgevec[0]
@@ -1029,7 +1028,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Formerly `StartPage.stratfunc`
         """
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return
         rellist = list(nx.line_graph(model_model.stratigraphic_dag))
@@ -1063,7 +1062,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         node_inside = "no node"
 
-        model_model: Optional[Model] = self.model.current_model
+        model_model = self.model.current_model
         if model_model is None:
             return node_inside
 
@@ -1090,7 +1089,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
                 node_inside = node_df.iloc[n_ind].name
         return node_inside
 
-    def node_del_popup(self, context_name: str) -> Optional[str]:
+    def node_del_popup(self, context_name: str) -> str | None:
         """Open a popup window for the user to provide input on deleting a node, returning the value
 
         This blocks users interacting with the main window until the popup is closed
@@ -1110,7 +1109,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         self.view.canvas["state"] = "normal"
         return data["reason"]
 
-    def edge_del_popup(self, context_a: str, context_b: str) -> Optional[str]:
+    def edge_del_popup(self, context_a: str, context_b: str) -> str | None:
         """Open a popup window for the user to provide input on deleting an edge, returning the reason provided
 
         This blocks users interacting with the main window until the popup is closed

--- a/src/polychron/presenters/PopupPresenter.py
+++ b/src/polychron/presenters/PopupPresenter.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, TypeVar
 
 from ..interfaces import Mediator
 from ..views.PopupView import PopupView
@@ -54,7 +56,7 @@ class PopupPresenter(ABC, Generic[ViewT, ModelT]):
         """Hide (withdraw) the view"""
         self.view.withdraw()
 
-    def close_view(self, event: Optional[Any] = None) -> None:
+    def close_view(self, event: Any = None) -> None:
         """Close the popup aftger performing any actions.
 
         This method should be overridden by presenters which require graceful destruction or wish to disable window closing."""

--- a/src/polychron/presenters/ProjectSelectProcessPopupPresenter.py
+++ b/src/polychron/presenters/ProjectSelectProcessPopupPresenter.py
@@ -1,4 +1,6 @@
-from typing import Dict, Optional
+from __future__ import annotations
+
+from typing import Dict
 
 from ..interfaces import Mediator
 from ..models.ProjectSelection import ProjectSelection
@@ -44,13 +46,13 @@ class ProjectSelectProcessPopupPresenter(PopupPresenter[ProjectSelectProcessPopu
     def update_view(self) -> None:
         pass
 
-    def get_presenter(self, key: Optional[str]) -> Optional[FramePresenter]:
+    def get_presenter(self, key: str | None) -> FramePresenter | None:
         if key is not None and key in self.presenters:
             return self.presenters[key]
         else:
             return None
 
-    def switch_presenter(self, key: Optional[str]) -> None:
+    def switch_presenter(self, key: str | None) -> None:
         if new_presenter := self.get_presenter(key):
             # Hide the current presenter if set
             if current_presenter := self.get_presenter(self.current_presenter_key):

--- a/src/polychron/presenters/RemoveContextPresenter.py
+++ b/src/polychron/presenters/RemoveContextPresenter.py
@@ -1,17 +1,19 @@
-from typing import Dict, Optional
+from __future__ import annotations
+
+from typing import Dict
 
 from ..interfaces import Mediator
 from ..views.RemoveContextView import RemoveContextView
 from .PopupPresenter import PopupPresenter
 
 
-class RemoveContextPresenter(PopupPresenter[RemoveContextView, Dict[str, Optional[str]]]):
+class RemoveContextPresenter(PopupPresenter[RemoveContextView, Dict[str, str | None]]):
     """Presenter for a popup window to input the reason for the removal of a node/context
 
     Formerly `popupWindow5`, called by StartPage.node_del_popup, triggered when "Delete context" is selected on a node
     """
 
-    def __init__(self, mediator: Mediator, view: RemoveContextView, model: Dict[str, Optional[str]]) -> None:
+    def __init__(self, mediator: Mediator, view: RemoveContextView, model: Dict[str, str | None]) -> None:
         # Call the parent class' consturctor
         super().__init__(mediator, view, model)
 

--- a/src/polychron/presenters/RemoveStratigraphicRelationshipPresenter.py
+++ b/src/polychron/presenters/RemoveStratigraphicRelationshipPresenter.py
@@ -1,4 +1,6 @@
-from typing import Dict, Optional
+from __future__ import annotations
+
+from typing import Dict
 
 from ..interfaces import Mediator
 from ..views.RemoveStratigraphicRelationshipView import RemoveStratigraphicRelationshipView
@@ -6,7 +8,7 @@ from .PopupPresenter import PopupPresenter
 
 
 class RemoveStratigraphicRelationshipPresenter(
-    PopupPresenter[RemoveStratigraphicRelationshipView, Dict[str, Optional[str]]]
+    PopupPresenter[RemoveStratigraphicRelationshipView, Dict[str, str | None]]
 ):
     """Presenter for a popup window to provide the reason for the removal of a single stratigraphic relationship
 
@@ -14,7 +16,7 @@ class RemoveStratigraphicRelationshipPresenter(
     """
 
     def __init__(
-        self, mediator: Mediator, view: RemoveStratigraphicRelationshipView, model: Dict[str, Optional[str]]
+        self, mediator: Mediator, view: RemoveStratigraphicRelationshipView, model: Dict[str, str | None]
     ) -> None:
         # Call the parent class' consturctor
         super().__init__(mediator, view, model)

--- a/src/polychron/presenters/ResidualOrIntrusivePresenter.py
+++ b/src/polychron/presenters/ResidualOrIntrusivePresenter.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import copy
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 import networkx as nx
 from PIL import ImageTk
@@ -23,7 +25,7 @@ class ResidualOrIntrusivePresenter(PopupPresenter[ResidualOrIntrusiveView, Model
         # Call the parent class' consturctor
         super().__init__(mediator, view, model)
 
-        self.mode: Optional[Literal["resid", "intru"]] = None
+        self.mode: Literal["resid", "intru"] | None = None
         """The currently selected mode, either None, "resid" or "intru"
         
         Formerly PageTwo.modevariable

--- a/src/polychron/presenters/SplashPresenter.py
+++ b/src/polychron/presenters/SplashPresenter.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from ..interfaces import Mediator
 from ..models.ProjectSelection import ProjectSelection
@@ -18,7 +18,7 @@ class SplashPresenter(FramePresenter[SplashView, ProjectSelection]):
         # Call the parent class' consturctor
         super().__init__(mediator, view, model)
 
-        self.child_presenter: Optional[ProjectSelectProcessPopupPresenter] = None
+        self.child_presenter: ProjectSelectProcessPopupPresenter | None = None
 
         # Build file/view/tool menus with callbacks
         self.view.build_file_menu(

--- a/src/polychron/util.py
+++ b/src/polychron/util.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import ast
 import re
 import time
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 import networkx as nx
 import numpy as np
@@ -544,8 +546,8 @@ def edge_label(src: str, dst: str) -> str:
 class MonotonicTimer:
     """A monotonic timer, for capturing execution time for sections of code"""
 
-    __start: Optional[int] = None
-    __stop: Optional[int] = None
+    __start: int | None = None
+    __stop: int | None = None
 
     def start(self) -> "MonotonicTimer":
         """Record the start of the timed period

--- a/src/polychron/views/AddContextView.py
+++ b/src/polychron/views/AddContextView.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import tkinter as tk
 from tkinter import ttk
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from .PopupView import PopupView
 
@@ -34,7 +36,7 @@ class AddContextView(PopupView):
         self.ok_button = ttk.Button(self, text="Ok")
         self.ok_button.pack()
 
-    def bind_ok_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_ok_button(self, callback: Callable[[], Any | None]) -> None:
         """Bind the callback for when the ok_button is pressed"""
         if callback is not None:
             self.ok_button.config(command=callback)

--- a/src/polychron/views/CalibrateModelSelectView.py
+++ b/src/polychron/views/CalibrateModelSelectView.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import tkinter as tk
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List
 
 from .PopupView import PopupView
 
@@ -40,12 +42,12 @@ class CalibrateModelSelectView(PopupView):
         )
         self.select_all_button.place(relx=0.6, rely=0.7)
 
-    def bind_ok_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_ok_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the ok_button is pressed"""
         if callback is not None:
             self.ok_button.config(command=callback)
 
-    def bind_select_all_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_select_all_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the select_all_button is pressed"""
         if callback is not None:
             self.select_all_button.config(command=callback)

--- a/src/polychron/views/DatafilePreviewView.py
+++ b/src/polychron/views/DatafilePreviewView.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import tkinter as tk
 from tkinter import ttk
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from .PopupView import PopupView
 
@@ -32,12 +34,12 @@ class DatafilePreviewView(PopupView):
         self.cancel_button = tk.Button(self, text="Cancel", bg="#2F4858", font=("Helvetica 12 bold"), fg="#eff3f6")
         self.cancel_button.pack()
 
-    def bind_load_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_load_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the load_button is pressed"""
         if callback is not None:
             self.load_button.config(command=callback)
 
-    def bind_cancel_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_cancel_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the cancel_button is pressed"""
         if callback is not None:
             self.cancel_button.config(command=callback)

--- a/src/polychron/views/DatingResultsView.py
+++ b/src/polychron/views/DatingResultsView.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import tkinter as tk
 from tkinter import ttk
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Tuple
 
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
@@ -37,10 +39,10 @@ class DatingResultsView(FrameView):
         self.results_text = None
         """tkinter text handle within the littlecanvas3."""
 
-        self.canvas_plt: Optional[FigureCanvasTkAgg] = None
+        self.canvas_plt: FigureCanvasTkAgg | None = None
         """Canvas which cotnains a plot"""
 
-        self.toolbar: Optional[NavigationToolbar2Tk] = None
+        self.toolbar: NavigationToolbar2Tk | None = None
         """Matplotlib toolkbar for the canvas_plt if it exists"""
 
         self.configure(background="#fcfdfd")
@@ -194,7 +196,7 @@ class DatingResultsView(FrameView):
         ]
         self.__testmenu2_variable = tk.StringVar(self.littlecanvas)
         self.__testmenu2_variable.set("Add to results list")
-        self.__testmenu2_callback: Callable[[], Optional[Any]] = lambda event: None
+        self.__testmenu2_callback: Callable[[], Any] = lambda event: None
         self.testmenu2 = ttk.OptionMenu(
             self.littlecanvas2,
             self.__testmenu2_variable,
@@ -211,39 +213,39 @@ class DatingResultsView(FrameView):
         """Set the value for the testmenu"""
         return self.__testmenu2_variable.set(value)
 
-    def bind_testmenu2_commands(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_testmenu2_commands(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for the stratigraphic graph right-click menu
 
         ttk.OptionMenu doesn not accept commadns to .config, only on the constructor? So in this case the view contains a reference to the callback
         """
         self.__testmenu2_callback = callback
 
-    def bind_sasd_tab_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_sasd_tab_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the sasd_tab_button is pressed"""
         if callback is not None:
             self.sasd_tab_button.config(command=callback)
 
-    def bind_dr_tab_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_dr_tab_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the dr_tab_button is pressed"""
         if callback is not None:
             self.dr_tab_button.config(command=callback)
 
-    def bind_posterior_densities_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_posterior_densities_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the posterior_densities_button is pressed"""
         if callback is not None:
             self.posterior_densities_button.config(command=callback)
 
-    def bind_hpd_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_hpd_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the hpd_button is pressed"""
         if callback is not None:
             self.hpd_button.config(command=callback)
 
-    def bind_clear_list_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_clear_list_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the clear_list_button is pressed"""
         if callback is not None:
             self.clear_list_button.config(command=callback)
 
-    def bind_littlecanvas2_callback(self, sequence: str, callback: Callable[[], Optional[Any]]):
+    def bind_littlecanvas2_callback(self, sequence: str, callback: Callable[[], Any]):
         """Bind a single callback to the specified sequence on the littlecanvas2. This is an alternative to an all in one bind method, as the canvas repeatedly gets cleared"""
         self.littlecanvas2.bind(sequence, callback)
 
@@ -253,10 +255,10 @@ class DatingResultsView(FrameView):
 
     def bind_littlecanvas2_events(
         self,
-        callback_wheel: Callable[[], Optional[Any]],
-        callback_rightclick: Callable[[], Optional[Any]],
-        callback_move_from: Callable[[], Optional[Any]],
-        callback_move_to: Callable[[], Optional[Any]],
+        callback_wheel: Callable[[], Any],
+        callback_rightclick: Callable[[], Any],
+        callback_move_from: Callable[[], Any],
+        callback_move_to: Callable[[], Any],
     ) -> None:
         """Bind mouse callback events for interacting with the graph canvas"""
         self.littlecanvas2.bind("<MouseWheel>", callback_wheel)
@@ -266,7 +268,7 @@ class DatingResultsView(FrameView):
         self.littlecanvas2.bind("<Button-1>", callback_move_from)
         self.littlecanvas2.bind("<B1-Motion>", callback_move_to)
 
-    def build_file_menu(self, items: List[Optional[Tuple[str, Callable[[], Optional[Any]]]]]) -> None:
+    def build_file_menu(self, items: List[Tuple[str, Callable[[], Any]] | None]) -> None:
         """Builds the 'file' menu element with labels and callback functions.
 
         Parameters:
@@ -290,7 +292,7 @@ class DatingResultsView(FrameView):
         if len(items) > 0:
             menubar.configure(state=tk.NORMAL)
 
-    def build_view_menu(self, items: List[Optional[Tuple[str, Callable[[], Optional[Any]]]]]) -> None:
+    def build_view_menu(self, items: List[Tuple[str, Callable[[], Any]] | None]) -> None:
         """Builds the 'view' menu element with labels and callback functions.
 
         Parameters:
@@ -314,7 +316,7 @@ class DatingResultsView(FrameView):
         if len(items) > 0:
             menubar.configure(state=tk.NORMAL)
 
-    def build_tool_menu(self, items: List[Optional[Tuple[str, Callable[[], Optional[Any]]]]]) -> None:
+    def build_tool_menu(self, items: List[Tuple[str, Callable[[], Any]] | None]) -> None:
         """Builds the 'tools' menu element with labels and callback functions.
 
         Parameters:
@@ -437,7 +439,7 @@ class DatingResultsView(FrameView):
         self.littlecanvas2.scale("all", 0, 0, scale2, scale2)  # rescale all canvas objects
         self.show_image2()
 
-    def show_testmenu(self, has_image: bool) -> Tuple[Optional[int], Optional[int]]:
+    def show_testmenu(self, has_image: bool) -> Tuple[int | None, int | None]:
         """Show the test menu within the little canvas2 at the cursors' coordinates
 
         Formerly part of PageOne.onRight

--- a/src/polychron/views/ManageGroupRelationshipsView.py
+++ b/src/polychron/views/ManageGroupRelationshipsView.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import tkinter as tk
 from tkinter import ttk
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import pandas as pd
 
@@ -30,22 +32,22 @@ class ManageGroupRelationshipsView(PopupView):
         self.label_dict = {}
         """Dictionary of phases boxes/tkinter label elements"""
 
-        self.__phase_box_move_callback: Callable[[], Optional[Any]] = lambda event: None
+        self.__phase_box_move_callback: Callable[[], Any] = lambda event: None
         """Callback method for when a phase box is moved."""
 
-        self.__confirm_callback: Callable[[], Optional[Any]] = lambda: None
+        self.__confirm_callback: Callable[[], Any] = lambda: None
         """Callback method for when the confirm button is pressed. 
         
         Stored in the view to allow deletion and recreation of the confirm button.
         """
 
-        self.__render_callback: Callable[[], Optional[Any]] = lambda: None
+        self.__render_callback: Callable[[], Any] = lambda: None
         """Callback method for when the render button is pressed. 
         
         Stored in the view to allow deletion and recreation of the render button.
         """
 
-        self.__change_callback: Callable[[], Optional[Any]] = lambda: None
+        self.__change_callback: Callable[[], Any] = lambda: None
         """Callback method for when the change button is pressed. 
         
         Stored in the view to allow deletion and recreation of the change button.
@@ -479,7 +481,7 @@ class ManageGroupRelationshipsView(PopupView):
         ]
         """List of tkinter string colours used for phase boxes."""
 
-    def create_phase_boxes(self, phase_labels: Optional[List[Tuple[str, str]]]) -> None:
+    def create_phase_boxes(self, phase_labels: List[Tuple[str, str]] | None) -> None:
         """Create a box within the canvas for each provided phase label"""
         self.label_dict = {}
 
@@ -509,7 +511,7 @@ class ManageGroupRelationshipsView(PopupView):
         """Update the canvas to ensure coordinates are correct?"""
         self.canvas.update()
 
-    def update_tree_2col(self, group_relationships: Optional[List[Tuple[str, str]]]) -> None:
+    def update_tree_2col(self, group_relationships: List[Tuple[str, str]] | None) -> None:
         """Update the table of group relationships to the value(s) provided by the user
 
         This is the 2 column version, for the first step in the residual checking process.
@@ -579,7 +581,7 @@ class ManageGroupRelationshipsView(PopupView):
             self.tree.insert("", 0, text=index, values=list(row))
         self.tree["show"] = "headings"
 
-    def bind_phase_box_on_move(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_phase_box_on_move(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for moving the phase boxes.
 
         This is set on a (private) view class member, to avoid havnig to call this method again if the phase boxes are ever re-generated.
@@ -587,17 +589,17 @@ class ManageGroupRelationshipsView(PopupView):
         if callback is not None:
             self.__phase_box_move_callback = callback
 
-    def bind_confirm_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_confirm_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the confirm_button is pressed"""
         if callback is not None:
             self.__confirm_callback = callback
 
-    def bind_render_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_render_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the render_button is pressed"""
         if callback is not None:
             self.__render_callback = callback
 
-    def bind_change_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_change_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the change_button is pressed"""
         if callback is not None:
             self.__change_callback = callback

--- a/src/polychron/views/ManageIntrusiveOrResidualContextsView.py
+++ b/src/polychron/views/ManageIntrusiveOrResidualContextsView.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import tkinter as tk
 from tkinter import ttk
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List
 
 from .PopupView import PopupView
 
@@ -44,12 +46,12 @@ class ManageIntrusiveOrResidualContextsView(PopupView):
         )
         self.proceed_button.grid(column=30, row=6)
 
-    def bind_back_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_back_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the back_button is pressed"""
         if callback is not None:
             self.back_button.config(command=callback)
 
-    def bind_proceed_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_proceed_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the proceed_button is pressed"""
         if callback is not None:
             self.proceed_button.config(command=callback)

--- a/src/polychron/views/ModelCreateView.py
+++ b/src/polychron/views/ModelCreateView.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import tkinter as tk
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from .FrameView import FrameView
 
@@ -32,13 +34,13 @@ class ModelCreateView(FrameView):
         self.back_button.place(relx=0.21, rely=0.01)
         self.back_button.bind("<Return>", lambda event: self.back_button.invoke())
 
-    def bind_submit_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_submit_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the submit_button is pressed"""
         if callback is not None:
             self.submit_button.config(command=callback)
             self.user_input.bind("<Return>", (lambda event: callback()))
 
-    def bind_back_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_back_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the back button is pressed"""
         if callback is not None:
             self.back_button.config(command=callback)

--- a/src/polychron/views/ModelSelectView.py
+++ b/src/polychron/views/ModelSelectView.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import tkinter as tk
 from tkinter import ttk
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List
 
 from .FrameView import FrameView
 
@@ -45,24 +47,24 @@ class ModelSelectView(FrameView):
         self.create_model_button.place(relx=0.62, rely=0.9, relwidth=0.17)
         self.create_model_button.bind("<Return>", lambda event: self.create_model_button.invoke())
 
-    def bind_load_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_load_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the load_button is pressed & when enter is pressed with a list item selected"""
         if callback is not None:
             self.load_button.config(command=callback)
             self.model_listbox.bind("<Return>", lambda event: callback())
             self.model_listbox.bind("<Double-1>", lambda event: callback())
 
-    def bind_back_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_back_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the back_button is pressed"""
         if callback is not None:
             self.back_button.config(command=callback)
 
-    def bind_create_model_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_create_model_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the create_model_button is pressed"""
         if callback is not None:
             self.create_model_button.config(command=callback)
 
-    def bind_list_select(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_list_select(self, callback: Callable[[], Any]) -> None:
         if callback is not None:
             self.model_listbox.bind("<<ListboxSelect>>", callback)
 
@@ -73,7 +75,7 @@ class ModelSelectView(FrameView):
         # Insert the new entries
         self.model_listbox.insert(tk.END, *model_names)
 
-    def get_selected_model(self) -> Optional[str]:
+    def get_selected_model(self) -> str | None:
         """Get the value of the currently selected model name"""
         selected_index = self.model_listbox.curselection()
         if selected_index:

--- a/src/polychron/views/ModelView.py
+++ b/src/polychron/views/ModelView.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import tkinter as tk
 from tkinter import ttk
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Tuple
 
 import pandas as pd
 from PIL import Image, ImageTk
@@ -122,7 +124,7 @@ class ModelView(FrameView):
         ]
         self.__testmenu_variable = tk.StringVar(self.littlecanvas)
         self.__testmenu_variable.set("Node Action")
-        self.__testmenu_callback: Callable[[], Optional[Any]] = lambda event: None
+        self.__testmenu_callback: Callable[[], Any] = lambda event: None
         """reference to the callback method for the test menu, as it does not appear that an OptionMenu(command) can be changed after construction."""
         self.testmenu = ttk.OptionMenu(
             self.littlecanvas,
@@ -195,29 +197,29 @@ class ModelView(FrameView):
         """Set the value for the testmenu"""
         return self.__testmenu_variable.set(value)
 
-    def bind_testmenu_commands(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_testmenu_commands(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for the stratigraphic graph right-click menu
 
         ttk.OptionMenu doesn not accept commadns to .config, only on the constructor? So in this case the view contains a reference to the callback
         """
         self.__testmenu_callback = callback
 
-    def bind_sasd_tab_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_sasd_tab_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the sasd_tab_button is pressed"""
         if callback is not None:
             self.sasd_tab_button.config(command=callback)
 
-    def bind_dr_tab_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_dr_tab_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the dr_tab_button is pressed"""
         if callback is not None:
             self.dr_tab_button.config(command=callback)
 
-    def bind_data_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_data_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the data_button is pressed"""
         if callback is not None:
             self.data_button.config(command=callback)
 
-    def bind_littlecanvas_callback(self, sequence: str, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_littlecanvas_callback(self, sequence: str, callback: Callable[[], Any]) -> None:
         """Bind a single callback to the specified sequence on the littlecanvas. This is an alternative to an all in one bind method, as the canvas repeatedly gets cleared"""
         self.littlecanvas.bind(sequence, callback)
 
@@ -225,7 +227,7 @@ class ModelView(FrameView):
         """Unbind a single callback to the specified sequence on the littlecanvas. This is an alternative to an all in one bind method, as the canvas repeatedly gets cleared"""
         self.littlecanvas.unbind(sequence)
 
-    def bind_littlecanvas2_callback(self, sequence: str, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_littlecanvas2_callback(self, sequence: str, callback: Callable[[], Any]) -> None:
         """Bind a single callback to the specified sequence on the littlecanvas2. This is an alternative to an all in one bind method, as the canvas repeatedly gets cleared"""
         self.littlecanvas2.bind(sequence, callback)
 
@@ -233,7 +235,7 @@ class ModelView(FrameView):
         """Unbind a single callback to the specified sequence on the littlecanvas2. This is an alternative to an all in one bind method, as the canvas repeatedly gets cleared"""
         self.littlecanvas2.unbind(sequence)
 
-    def show_testmenu(self, has_image: bool) -> Tuple[Optional[int], Optional[int]]:
+    def show_testmenu(self, has_image: bool) -> Tuple[int | None, int | None]:
         """Show the test menu within the little canvas at the cursors' coordinates
 
         Formerly part of StartPage.onRight
@@ -269,9 +271,9 @@ class ModelView(FrameView):
 
     def bind_littlecanvas_events(
         self,
-        callback_wheel: Callable[[], Optional[Any]],
-        callback_move_from: Callable[[], Optional[Any]],
-        callback_move_to: Callable[[], Optional[Any]],
+        callback_wheel: Callable[[], Any],
+        callback_move_from: Callable[[], Any],
+        callback_move_to: Callable[[], Any],
     ) -> None:
         """Bind mouse callback events for interacting with the graph canvas"""
         self.littlecanvas.bind("<MouseWheel>", callback_wheel)
@@ -282,9 +284,9 @@ class ModelView(FrameView):
 
     def bind_littlecanvas2_events(
         self,
-        callback_wheel: Callable[[], Optional[Any]],
-        callback_move_from: Callable[[], Optional[Any]],
-        callback_move_to: Callable[[], Optional[Any]],
+        callback_wheel: Callable[[], Any],
+        callback_move_from: Callable[[], Any],
+        callback_move_to: Callable[[], Any],
     ) -> None:
         """Bind mouse callback events for interacting with the graph canvas"""
         self.littlecanvas2.bind("<MouseWheel>", callback_wheel)
@@ -293,7 +295,7 @@ class ModelView(FrameView):
         self.littlecanvas2.bind("<Button-1>", callback_move_from)
         self.littlecanvas2.bind("<B1-Motion>", callback_move_to)
 
-    def build_file_menu(self, items: List[Optional[Tuple[str, Callable[[], Optional[Any]]]]]) -> None:
+    def build_file_menu(self, items: List[Tuple[str, Callable[[], Any]] | None]) -> None:
         """Builds the 'file' menu element with labels and callback functions.
 
         Parameters:
@@ -317,7 +319,7 @@ class ModelView(FrameView):
         if len(items) > 0:
             menubar.configure(state=tk.NORMAL)
 
-    def build_view_menu(self, items: List[Optional[Tuple[str, Callable[[], Optional[Any]]]]]) -> None:
+    def build_view_menu(self, items: List[Tuple[str, Callable[[], Any]] | None]) -> None:
         """Builds the 'view' menu element with labels and callback functions.
 
         Parameters:
@@ -341,7 +343,7 @@ class ModelView(FrameView):
         if len(items) > 0:
             menubar.configure(state=tk.NORMAL)
 
-    def build_tool_menu(self, items: List[Optional[Tuple[str, Callable[[], Optional[Any]]]]]) -> None:
+    def build_tool_menu(self, items: List[Tuple[str, Callable[[], Any]] | None]) -> None:
         """Builds the 'tools' menu element with labels and callback functions.
 
         Parameters:

--- a/src/polychron/views/PopupView.py
+++ b/src/polychron/views/PopupView.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import tkinter as tk
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict
 
 
 class PopupView(tk.Toplevel):
@@ -13,12 +15,12 @@ class PopupView(tk.Toplevel):
         self.parent = parent
         """A reference to the parent frame"""
 
-    def register_keybinds(self, bindings: Dict[str, Callable[[], Optional[Any]]]) -> None:
+    def register_keybinds(self, bindings: Dict[str, Callable[[], Any]]) -> None:
         """Register window-wide key bindings"""
         for sequence, callback in bindings.items():
             self.bind(sequence, callback)
 
-    def register_protocols(self, bindings: Dict[str, Callable[[], Optional[Any]]]) -> None:
+    def register_protocols(self, bindings: Dict[str, Callable[[], Any]]) -> None:
         """Register protocols with the window
 
         i.e. what happens when the window is closed using the OS decorations"""

--- a/src/polychron/views/ProjectCreateView.py
+++ b/src/polychron/views/ProjectCreateView.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import tkinter as tk
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from .FrameView import FrameView
 
@@ -33,13 +35,13 @@ class ProjectCreateView(FrameView):
         self.back_button.place(relx=0.21, rely=0.01)
         self.back_button.bind("<Return>", lambda event: self.back_button.invoke())
 
-    def bind_submit_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_submit_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the submit_button is pressed, or when the enter button is pressed."""
         if callback is not None:
             self.submit_button.config(command=callback)
             self.user_input.bind("<Return>", (lambda event: callback()))
 
-    def bind_back_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_back_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the back_button is pressed"""
         if callback is not None:
             self.back_button.config(command=callback)

--- a/src/polychron/views/ProjectSelectView.py
+++ b/src/polychron/views/ProjectSelectView.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import tkinter as tk
 from tkinter import ttk
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List
 
 from .FrameView import FrameView
 
@@ -39,18 +41,18 @@ class ProjectSelectView(FrameView):
         self.back_button.place(relx=0.21, rely=0.01)
         self.back_button.bind("<Return>", lambda event: self.back_button.invoke())
 
-    def bind_load_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_load_button(self, callback: Callable[[], Any]) -> None:
         """Callback function for the load button, which is also bound for <Return> events with a list box selected"""
         if callback is not None:
             self.load_button.config(command=callback)
             self.project_listbox.bind("<Return>", lambda event: callback())
             self.project_listbox.bind("<Double-1>", lambda event: callback())
 
-    def bind_back_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_back_button(self, callback: Callable[[], Any]) -> None:
         if callback is not None:
             self.back_button.config(command=callback)
 
-    def bind_list_select(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_list_select(self, callback: Callable[[], Any]) -> None:
         if callback is not None:
             self.project_listbox.bind("<<ListboxSelect>>", callback)
 
@@ -61,7 +63,7 @@ class ProjectSelectView(FrameView):
         # Insert the new entries
         self.project_listbox.insert(tk.END, *project_names)
 
-    def get_selected_project(self) -> Optional[str]:
+    def get_selected_project(self) -> str | None:
         """Get the value of the currently selected project name"""
         selected_index = self.project_listbox.curselection()
         if selected_index:

--- a/src/polychron/views/ProjectWelcomeView.py
+++ b/src/polychron/views/ProjectWelcomeView.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import importlib.resources
 import io
 import tkinter as tk
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from PIL import Image, ImageTk
 
@@ -58,12 +60,12 @@ class ProjectWelcomeView(FrameView):
         self.create_button.place(relx=0.62, rely=0.9)
         self.create_button.bind("<Return>", lambda event: self.create_button.invoke())
 
-    def bind_load_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_load_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the load_button is pressed"""
         if callback is not None:
             self.load_button.config(command=callback)
 
-    def bind_create_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_create_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the create_button is pressed"""
         if callback is not None:
             self.create_button.config(command=callback)

--- a/src/polychron/views/RemoveContextView.py
+++ b/src/polychron/views/RemoveContextView.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import tkinter as tk
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from .PopupView import PopupView
 
@@ -38,12 +40,12 @@ class RemoveContextView(PopupView):
         self.ok_button = tk.Button(self, text="OK", bg="#2F4858", font=("Helvetica 12 bold"), fg="#eff3f6")
         self.ok_button.place(relx=0.3, rely=0.7)
 
-    def bind_ok_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_ok_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the ok_button is pressed"""
         if callback is not None:
             self.ok_button.config(command=callback)
 
-    def update_label(self, context: Optional[str] = None) -> None:
+    def update_label(self, context: str | None = None) -> None:
         """Update the label text to include the context being removed."""
         context_name = "this context" if context is None else f"'{context}'"
         self.label.configure(text=f"Why are you removing {context_name} from your stratigraphy?")

--- a/src/polychron/views/RemoveStratigraphicRelationshipView.py
+++ b/src/polychron/views/RemoveStratigraphicRelationshipView.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import tkinter as tk
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from .PopupView import PopupView
 
@@ -38,12 +40,12 @@ class RemoveStratigraphicRelationshipView(PopupView):
         self.ok_button = tk.Button(self, text="OK", bg="#2F4858", font=("Helvetica 12 bold"), fg="#eff3f6")
         self.ok_button.place(relx=0.3, rely=0.7)
 
-    def bind_ok_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_ok_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the ok_button is pressed"""
         if callback is not None:
             self.ok_button.config(command=callback)
 
-    def update_label(self, edge_label: Optional[str] = None) -> None:
+    def update_label(self, edge_label: str | None = None) -> None:
         """Update the label text to include the edge being removed."""
         edge_label = "these contexts" if edge_label is None else f"{edge_label}"
         self.label.configure(text=f"Why are you deleting the stratigraphic relationship between {edge_label}?")

--- a/src/polychron/views/ResidualOrIntrusiveView.py
+++ b/src/polychron/views/ResidualOrIntrusiveView.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import tkinter as tk
 from tkinter import ttk
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List
 
 from PIL import Image, ImageTk
 
@@ -26,7 +28,7 @@ class ResidualOrIntrusiveView(PopupView):
         self.transy2 = 0
         self.width2 = 0
         self.height2 = 0
-        self.image2: Optional[Image.Image] = None  # in-memory rendered image.
+        self.image2: Image.Image | None = None  # in-memory rendered image.
 
         self.title("Identify Residual or Intrusive Contexts")
         self.configure(bg="#AEC7D6")
@@ -88,17 +90,17 @@ class ResidualOrIntrusiveView(PopupView):
         """Update the intrusive list"""
         self.intru_label["text"] = str(intrusive_contexts).replace("'", "")[1:-1]
 
-    def bind_proceed_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_proceed_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the proceed_button is pressed"""
         if callback is not None:
             self.proceed_button.config(command=callback)
 
-    def bind_residual_mode_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_residual_mode_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the residual_mode_button is pressed"""
         if callback is not None:
             self.residual_mode_button.config(command=callback)
 
-    def bind_intrusive_mode_button(self, callback: Callable[[], Optional[Any]]) -> None:
+    def bind_intrusive_mode_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the intrusive_mode_button is pressed"""
         if callback is not None:
             self.intrusive_mode_button.config(command=callback)
@@ -111,10 +113,10 @@ class ResidualOrIntrusiveView(PopupView):
 
     def bind_graphcanvas_events(
         self,
-        callback_wheel: Callable[[], Optional[Any]],
-        callback_node_click: Callable[[], Optional[Any]],
-        callback_move_from: Callable[[], Optional[Any]],
-        callback_move_to: Callable[[], Optional[Any]],
+        callback_wheel: Callable[[], Any],
+        callback_node_click: Callable[[], Any],
+        callback_move_from: Callable[[], Any],
+        callback_move_to: Callable[[], Any],
     ) -> None:
         """Bind mouse callback events for interacting with the graph canvas"""
         self.graphcanvas.bind("<MouseWheel>", callback_wheel)

--- a/src/polychron/views/SplashView.py
+++ b/src/polychron/views/SplashView.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import importlib.resources
 import io
 import tkinter as tk
 from tkinter import ttk
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Tuple
 
 from PIL import Image, ImageTk
 
@@ -68,7 +70,7 @@ class SplashView(FrameView):
         canvas_center_y = (0.97 * self.parent.winfo_height()) / 2
         self.canvas.coords(self.canvas_img_id, canvas_center_x, canvas_center_y)
 
-    def build_file_menu(self, items: List[Optional[Tuple[str, Callable[[], Optional[Any]]]]]) -> None:
+    def build_file_menu(self, items: List[Tuple[str, Callable[[], Any]] | None]) -> None:
         """Builds the 'file' menu element with labels and callback functions.
 
         Parameters:


### PR DESCRIPTION
Replace `Optional` type hints with the nicer syntax from python 3.10+ `| None'` via `from __future__ import annotations`

Closes #90