### PR TITLE
Fix invalid typehint for python 3.9 through `__future__`

### DIFF
--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import filecmp
 import json


### PR DESCRIPTION
Fixes a runtime error during the import of `Model.py` on Python 3.9 caused by the use of python 3.10+ type hint syntax `|` in stead of `Union`. 

This was addressed by enabling python 3.10+ type hint syntax through a `__future__` import. 


This was unintentionally included in #177, and was not caught by CI due to the sparse test suite.

Related to #182