### PR TITLE
Fix: Missed function rename in `ModelPresenter.open_context_equalities_file`

### DIFF
--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -457,7 +457,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
                 df = pd.read_csv(file)
                 df = df.applymap(str)
                 # Update the model & post process, updating the graph
-                model_model.set_equal_rel_df(df)
+                model_model.set_context_equality_df(df)
 
                 # Render the image in phases or not
                 model_model.render_strat_graph()


### PR DESCRIPTION
Fix: Missed function rename in `ModelPresenter.open_context_equalities_file`, broken in #177 