### PR TITLE
Fix context equalities setting for python 3.9 / Networkx < 3.4 support

### DIFF
--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -24,7 +24,15 @@ from PIL import Image
 from ..automated_mcmc_ordering_coupling_copy import run_MCMC
 from ..Config import get_config
 from ..models.MCMCData import MCMCData
-from ..util import MonotonicTimer, node_coords_fromjson, phase_info_func, phase_labels, rank_func, trim
+from ..util import (
+    MonotonicTimer,
+    node_coords_fromjson,
+    phase_info_func,
+    phase_labels,
+    rank_func,
+    remove_invalid_attributes_networkx_lt_3_4,
+    trim,
+)
 from .InterpolatedRCDCalibrationCurve import InterpolatedRCDCalibrationCurve
 
 
@@ -682,6 +690,8 @@ class Model:
         workdir = self.get_working_directory()
         workdir.mkdir(parents=True, exist_ok=True)
         self.stratigraphic_dag.graph["graph"] = {"splines": "ortho"}
+        # Ensure the graph is compatible with networkx < 3.4 nx_pydot
+        self.stratigraphic_dag = remove_invalid_attributes_networkx_lt_3_4(self.stratigraphic_dag)
         write_dot(self.stratigraphic_dag, workdir / "fi_new")
         render("dot", "png", workdir / "fi_new")
         render("dot", "svg", workdir / "fi_new")
@@ -699,6 +709,8 @@ class Model:
         workdir = self.get_working_directory()
         workdir.mkdir(parents=True, exist_ok=True)
 
+        # Ensure the graph is compatible with networkx < 3.4 nx_pydot
+        self.stratigraphic_dag = remove_invalid_attributes_networkx_lt_3_4(self.stratigraphic_dag)
         write_dot(self.stratigraphic_dag, workdir / "fi_new.txt")
         my_file = open(workdir / "fi_new.txt")
         file_content = my_file.read()
@@ -724,6 +736,8 @@ class Model:
         workdir.mkdir(exist_ok=True)
 
         self.resid_or_intru_dag.graph["graph"] = {"splines": "ortho"}
+        # Ensure the graph is compatible with networkx < 3.4 nx_pydot
+        self.resid_or_intru_dag = remove_invalid_attributes_networkx_lt_3_4(self.resid_or_intru_dag)
         write_dot(self.resid_or_intru_dag, workdir / "fi_new")
         render("dot", "png", workdir / "fi_new")
         render("dot", "svg", workdir / "fi_new")
@@ -740,7 +754,8 @@ class Model:
         """
         workdir = self.get_working_directory() / "resid_or_intru"
         workdir.mkdir(exist_ok=True)
-
+        # Ensure the graph is compatible with networkx < 3.4 nx_pydot
+        self.resid_or_intru_dag = remove_invalid_attributes_networkx_lt_3_4(self.resid_or_intru_dag)
         write_dot(self.resid_or_intru_dag, workdir / "fi_new.txt")
         my_file = open(workdir / "fi_new.txt")
         file_content = my_file.read()

--- a/src/polychron/presenters/ManageGroupRelationshipsPresenter.py
+++ b/src/polychron/presenters/ManageGroupRelationshipsPresenter.py
@@ -5,12 +5,11 @@ from typing import Any
 
 import networkx as nx
 import numpy as np
-import packaging.version
 from networkx.drawing.nx_pydot import write_dot
 
 from ..interfaces import Mediator
 from ..models.Model import Model
-from ..util import chrono_edge_add, chrono_edge_remov, node_del_fixed
+from ..util import chrono_edge_add, chrono_edge_remov, node_del_fixed, remove_invalid_attributes_networkx_lt_3_4
 from ..views.ManageGroupRelationshipsView import ManageGroupRelationshipsView
 from .PopupPresenter import PopupPresenter
 
@@ -265,11 +264,8 @@ class ManageGroupRelationshipsPresenter(PopupPresenter[ManageGroupRelationshipsV
         for b in edge_remove:
             self.graphcopy.remove_edge(b[0], b[1])
 
-        # networkx.drawing.nx_pydot.write_dot from networkx < 3.4 does not quote node attributes correctly if they contain characters such as :. Networkx 3.4 is only available for pythono >= 3.10, so a workaround is required for python 3.9 users.
-        if packaging.version.parse(nx.__version__) < packaging.version.parse("3.4.0"):
-            # Remove the contraction attribute from nodes.
-            for i in nodes:
-                self.graphcopy.nodes[i].pop("contraction", None)
+        # Ensure the graph is compatible with networkx < 3.4 nx_pydot
+        self.graphcopy = remove_invalid_attributes_networkx_lt_3_4(self.graphcopy)
 
         write_dot(self.graphcopy, workdir / "fi_new_chrono")
 


### PR DESCRIPTION
Setting context equalities leads to contraction attributes being assigned to edges rather than just nodes, which for versions of networkx available for python 3.9  (networkx < 3.4) would result in un-escaped : errors.

This ensures contraction attributs are removed from edges and nodes for affected versions of networkx before any use of nx_pydot.write_dot or nx_pydot.to_pydot, through the use of a new utililty function which returns a mutated copy of the graph if needed.