### PR TITLE
CI: Add ARM-based Ubuntu 24.04 CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
         python-version:
           - "3.9"
           - "3.10"


### PR DESCRIPTION
CI: Add ARM-based Ubuntu 24.04 CI

Closes #51 