### PR TITLE
Cancel Button for Delete Context pop-up window

### DIFF
--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -575,8 +575,11 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
                 if answer == "yes":
                     self.save_as_new_model()
                 # self.littlecanvas2.delete("all")
-            model_model.stratigraphic_dag = node_del_fixed(model_model.stratigraphic_dag, self.node)
             nodedel_reason = self.node_del_popup(self.node)
+            if nodedel_reason is None:
+                return
+            
+            model_model.stratigraphic_dag = node_del_fixed(model_model.stratigraphic_dag, self.node)
             model_model.record_deleted_node(self.node, nodedel_reason)
             self.view.append_deleted_node(self.node, nodedel_reason)
 

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -578,7 +578,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
             nodedel_reason = self.node_del_popup(self.node)
             if nodedel_reason is None:
                 return
-            
+
             model_model.stratigraphic_dag = node_del_fixed(model_model.stratigraphic_dag, self.node)
             model_model.record_deleted_node(self.node, nodedel_reason)
             self.view.append_deleted_node(self.node, nodedel_reason)

--- a/src/polychron/presenters/RemoveContextPresenter.py
+++ b/src/polychron/presenters/RemoveContextPresenter.py
@@ -18,6 +18,9 @@ class RemoveContextPresenter(PopupPresenter[RemoveContextView, Dict[str, Optiona
         # Bind buttons
         self.view.bind_ok_button(self.on_ok_button)
 
+        # Bind the cancel button
+        self.view.bind_cancel_button(self.on_cancel)
+
         # Update view information to reflect the current state of the model
         self.update_view()
 
@@ -30,4 +33,9 @@ class RemoveContextPresenter(PopupPresenter[RemoveContextView, Dict[str, Optiona
         # Store the provided reason in the model
         self.model["reason"] = self.view.get_reason()
         # Close the popup
+        self.close_view()
+
+    def on_cancel(self) -> None:
+        """When the Cancel button is pressed, close the popup without changing the model"""
+        self.model["reason"] = None
         self.close_view()

--- a/src/polychron/views/RemoveContextView.py
+++ b/src/polychron/views/RemoveContextView.py
@@ -41,7 +41,9 @@ class RemoveContextView(PopupView):
         self.ok_button.place(relx=0.3, rely=0.7)
 
         # Cancel Button
-        self.cancel_button = tk.Button(self, text="Cancel", bg="#2F4858", font=("Helvetica 12 bold"), fg="#eff3f6" ,command=self.destroy)
+        self.cancel_button = tk.Button(
+            self, text="Cancel", bg="#2F4858", font=("Helvetica 12 bold"), fg="#eff3f6", command=self.destroy
+        )
         self.cancel_button.place(relx=0.72625, rely=0.7)
 
     def bind_ok_button(self, callback: Callable[[], Any]) -> None:

--- a/src/polychron/views/RemoveContextView.py
+++ b/src/polychron/views/RemoveContextView.py
@@ -40,10 +40,19 @@ class RemoveContextView(PopupView):
         self.ok_button = tk.Button(self, text="OK", bg="#2F4858", font=("Helvetica 12 bold"), fg="#eff3f6")
         self.ok_button.place(relx=0.3, rely=0.7)
 
+        # Cancel Button
+        self.cancel_button = tk.Button(self, text="Cancel", bg="#2F4858", font=("Helvetica 12 bold"), fg="#eff3f6" ,command=self.destroy)
+        self.cancel_button.place(relx=0.72625, rely=0.7)
+
     def bind_ok_button(self, callback: Callable[[], Any]) -> None:
         """Bind the callback for when the ok_button is pressed"""
         if callback is not None:
             self.ok_button.config(command=callback)
+
+    def bind_cancel_button(self, callback: Callable[[], Any | None]) -> None:
+        """Bind the callback for when the cancel_button is pressed"""
+        if callback is not None:
+            self.cancel_button.config(command=callback)
 
     def update_label(self, context: str | None = None) -> None:
         """Update the label text to include the context being removed."""


### PR DESCRIPTION
Added a cancel button for the delete context pop-up window.
Closes #167 