### PR TITLE
Correct label tools and fix typos

### DIFF
--- a/src/polychron/Config.py
+++ b/src/polychron/Config.py
@@ -21,7 +21,7 @@ class Config:
     """The initial window geometry"""
 
     def __post_init__(self) -> None:
-        """Fixup member variabels post initialisation
+        """Fixup member variables post initialisation
 
         This ensures that environment variables and ~ have been expanded in the projects_directory
         """
@@ -76,7 +76,7 @@ class Config:
         # Ensure the parent exists before saving the file
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Attempt to save the yaml represenation to disk at the specified path
+        # Attempt to save the yaml representation to disk at the specified path
         try:
             with open(path, "w") as f:
                 yaml.dump(data, f, sort_keys=False)
@@ -101,7 +101,7 @@ class Config:
         """Get the default/expected file path for the config file on disk
 
         Returns:
-            The platform speicfic path to the expected configuration file location on disk
+            The platform specific path to the expected configuration file location on disk
         """
         return cls._get_config_dir() / "config.yaml"
 
@@ -120,17 +120,17 @@ class Config:
         return c
 
 
-# Module-scoped variable to hold a single instance of a configuration object, which can be accessed (and initialied) by calls to get_config
+# Module-scoped variable to hold a single instance of a configuration object, which can be accessed (and initialised) by calls to get_config
 __config_instance: Config = None
 
 
 def get_config() -> Config:
-    """Get the single 'global' Configuraiton object instance.
+    """Get the single 'global' Configuration object instance.
 
     On first call, the instance will be initialised to a value from disk, based on the platform-specific default location.
 
     Returns:
-        The single application wide Configuraiton object.
+        The single application wide Configuration object.
 
     Note:
         This is not thread-safe.

--- a/src/polychron/GUIApp.py
+++ b/src/polychron/GUIApp.py
@@ -34,7 +34,7 @@ class GUIApp(Mediator):
     """
 
     def __init__(self) -> None:
-        # Initialse the application config object
+        # Initialise the application config object
         self.config: Config = get_config()
 
         # Construct the root tkinter window, as a themed TK app

--- a/src/polychron/GUIApp.py
+++ b/src/polychron/GUIApp.py
@@ -197,7 +197,7 @@ class GUIApp(Mediator):
         splash_presenter = self.get_presenter("Splash")
 
         # Lazily load the projects directory, so (potential) existing models and projects are known.
-        self.project_selector_obj.projects_directiory.lazy_load()
+        self.project_selector_obj.projects_directory.lazy_load()
 
         # Instantiate the child presenter and view, which otherwise would be done by SplashPresenter.on_select_project. This does not start hidden
         popup_presenter = ProjectSelectProcessPopupPresenter(

--- a/src/polychron/GUIApp.py
+++ b/src/polychron/GUIApp.py
@@ -66,7 +66,7 @@ class GUIApp(Mediator):
         self.container.grid_rowconfigure(0, weight=1)
         self.container.grid_columnconfigure(0, weight=1)
 
-        # Instantiate the "global" applcation data object
+        # Instantiate the "global" application data object
         self.project_selector_obj: ProjectSelection = ProjectSelection(self.config.projects_directory)
 
         # Construct the views and presenters for main window views (i.e. not-popups)
@@ -80,7 +80,7 @@ class GUIApp(Mediator):
         # Place each main window within the container
         for presenter in self.presenters.values():
             presenter.view.grid(row=0, column=0, sticky="nsew")
-            # Immeditely hide the frame, but remember it's settings.
+            # Immediately hide the frame, but remember it's settings.
             presenter.view.grid_remove()
 
     def set_window_title(self, suffix: str | None = None) -> None:
@@ -223,7 +223,7 @@ class GUIApp(Mediator):
                     # Otherwise switch to the new model select popup
                     popup_presenter.switch_presenter("model_select")
             else:
-                # If we also have a model name, store it in the poject selection model
+                # If we also have a model name, store it in the project selection model
                 self.project_selector_obj.next_model_name = model_name
 
                 # Get the reason that the presenter is being closed.
@@ -232,7 +232,7 @@ class GUIApp(Mediator):
                 # Update the model to the "next" project & model.
                 self.project_selector_obj.switch_to_next_project_model(load_ok=True, create_ok=True)
 
-                # Close the popup window with the appropraite reason (load or new model)
+                # Close the popup window with the appropriate reason (load or new model)
                 popup_presenter.close_window(reason)
 
         # Start the render loop

--- a/src/polychron/entrypoint.py
+++ b/src/polychron/entrypoint.py
@@ -45,7 +45,7 @@ def main() -> None:
     """Main method as the entry point for launching the GUI"""
     args = parse_cli()
 
-    # if the versbose flag was set, ensure it is reflected in the config object
+    # if the verbose flag was set, ensure it is reflected in the config object
     if args.verbose:
         config = get_config()
         config.verbose = True
@@ -56,7 +56,7 @@ def main() -> None:
         print_version()
         return
     else:
-        # Import and lauch the GUI via an instance of the GUIApp class
+        # Import and launch the GUI via an instance of the GUIApp class
         from .GUIApp import GUIApp
 
         GUIApp().launch(project_name=args.project, model_name=args.model)

--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -256,7 +256,7 @@ class Model:
     """
 
     __calibration: Optional[InterpolatedRCDCalibrationCurve] = field(default=None, init=False, repr=False)
-    """Interpolated RCD calibration curve object, which is storedin a member variable so it is loaded once and only once"""
+    """Interpolated RCD calibration curve object, which is stored in a member variable so it is loaded once and only once"""
 
     def get_working_directory(self) -> pathlib.Path:
         """Get the working directory to be used for dynamically created files
@@ -299,7 +299,7 @@ class Model:
 
     def to_json(self, pretty: bool = False):
         """Serialise this object to JSON, excluding ephemeral members"""
-        # Create a dictionary contianing a subset of this instance's member variables, converted to formats which can be json serialised.
+        # Create a dictionary containing a subset of this instance's member variables, converted to formats which can be json serialised.
         data = {}
         exclude_keys = [
             "path",  # Don't include the path, so models can be trivially copied on disk
@@ -343,15 +343,15 @@ class Model:
         """Save the current state of this model to disk at self.path
 
         Raises:
-            Exception: raised when any error occured during saving, with a message to present to the user
+            Exception: raised when any error occurred during saving, with a message to present to the user
         """
 
-        # Ensure directories requried exist
+        # Ensure directories required exist
         if self.create_dirs():
             try:
                 timer_save = MonotonicTimer().start()
 
-                # create the represenation of the Model to be saved to disk
+                # create the representation of the Model to be saved to disk
                 timer_to_json = MonotonicTimer().start()
                 json_s = self.to_json(pretty=True)
                 timer_to_json.stop()
@@ -369,7 +369,7 @@ class Model:
                 self.save_deleted_contexts()
 
                 # Ensure the "saved" versions of files are up to date.
-                # Prepare a dictionary of per-output location files to copy form the wokring dir.
+                # Prepare a dictionary of per-output location files to copy form the working dir.
                 files_to_copy = {
                     self.get_chronological_graph_directory(): [
                         "fi_new_chrono.png",
@@ -410,7 +410,7 @@ class Model:
                 raise e
         else:
             raise RuntimeError(
-                'An error occured while creating Model directories, unable to save "polychron_model.json"'
+                'An error occurred while creating Model directories, unable to save "polychron_model.json"'
             )
 
     @classmethod
@@ -461,7 +461,7 @@ class Model:
 
             # Convert certain values back based on the hint for the data type.
             cls_type_hints = get_type_hints(cls)
-            # Get the class initiaser parameters so non-init feilds can be discarded
+            # Get the class initialiser parameters so non-init fields can be discarded
             init_parameters = set(signature(cls.__init__).parameters.keys())
             init_parameters.remove("self")
             # Also build a list of keys to remove
@@ -499,10 +499,10 @@ class Model:
             for k in keys_to_remove:
                 del model_data[k]
 
-            # Overwrite certain elements, i.e the path (in case the model fiels have been copied), but the path was included in the save file
+            # Overwrite certain elements, i.e the path (in case the model fields have been copied), but the path was included in the save file
             model_data["path"] = path
 
-            # Ensure that some elements are not stored, if they are explictly handled otherwise
+            # Ensure that some elements are not stored, if they are explicitly handled otherwise
             if "mcmc_data" in model_data:
                 del model_data["mcmc_data"]
 
@@ -547,7 +547,7 @@ class Model:
         Formerly part of load_Window.create_file, popupWindow9.make_directories & popupWindow10.make_directories"""
 
         try:
-            # Ensure the model (and implictly project) directory exists
+            # Ensure the model (and implicitly project) directory exists
             self.path.mkdir(parents=True, exist_ok=True)
             # Create each expected child directory.
             expected_model_dirs = [
@@ -606,7 +606,7 @@ class Model:
         self.stratigraphic_dag = G
 
     def set_radiocarbon_df(self, df: pd.DataFrame) -> None:
-        """Prodivided a datframe containing radiocarbon dating infromation for contexts, store a copy of the dataframe and mutate the stratigraphic dag
+        """Provided a dataframe containing radiocarbon dating information for contexts, store a copy of the dataframe and mutate the stratigraphic dag
 
         Parameters:
             df (pd.Dataframe): dataframe containing radiocarbon dating information. Expected columns ["context", "date", "error"]
@@ -645,7 +645,7 @@ class Model:
         Columns names are not currently expected/used, but there must be atleast 2 columns.
 
         Parameters:
-            df (pd.DataFrame): A dataframe containinig context equality data.
+            df (pd.DataFrame): A dataframe containing context equality data.
         """
         # Store a copy of the dataframe
         self.context_equality_df = df.copy()
@@ -663,8 +663,8 @@ class Model:
             self.stratigraphic_dag = nx.relabel_nodes(self.stratigraphic_dag, mapping)
 
     def render_strat_graph(self) -> None:
-        """Render the sratigraphic graph as a png and svg, with or without phasing depending on model state. Also updates the locatison of each node via the svg"""
-        # Call the appropraite render_strat method, depending if the model is set up to render in phases or not.
+        """Render the stratigraphic graph as a png and svg, with or without phasing depending on model state. Also updates the location of each node via the svg"""
+        # Call the appropriate render_strat method, depending if the model is set up to render in phases or not.
         if self.grouped_rendering:
             self.__render_strat_graph_phase()
         else:

--- a/src/polychron/models/Project.py
+++ b/src/polychron/models/Project.py
@@ -77,12 +77,12 @@ class Project:
 
         Raises:
             RuntimeError: if the model already exists or an invalid name is provided.
-            OSError: if the model directories could not be created, e.g. due to permissions or avialable space.
+            OSError: if the model directories could not be created, e.g. due to permissions or available space.
         """
 
         # Attempt to load the model with the provided name.
         existing_model = self.get_model(name)
-        # Raise an error if the model arlready exists
+        # Raise an error if the model already exists
         if existing_model is not None:
             raise RuntimeError(f"A model named '{name}' already exists at '{existing_model.path}'")
 
@@ -133,7 +133,7 @@ class Project:
             self.models[model.name] = model
 
         except Exception as e:
-            print(f"An exception occured when attempting to load {name}: {e}", file=sys.stderr)
+            print(f"An exception occurred when attempting to load {name}: {e}", file=sys.stderr)
             raise e
 
     def lazy_load(self) -> None:

--- a/src/polychron/models/ProjectSelection.py
+++ b/src/polychron/models/ProjectSelection.py
@@ -12,7 +12,7 @@ class ProjectSelection:
     """A class containing a ProjectsDirectory object, and variables related to the currently selected project/model, and the next project/model to be slelected"""
 
     def __init__(self, projects_directory_path: pathlib.Path):
-        """Initailse an instance of the ProjectSelection class, using a projects directory from a specified path."""
+        """Initialise an instance of the ProjectSelection class, using a projects directory from a specified path."""
 
         # Expand ~ and any env vars in the provided path, in case they are in the config provided path
         projects_directory_path = pathlib.Path(os.path.expandvars(projects_directory_path.expanduser()))
@@ -45,7 +45,7 @@ class ProjectSelection:
         """
 
     @property
-    def projects_directiory(self) -> ProjectsDirectory:
+    def projects_directory(self) -> ProjectsDirectory:
         """Get (a ref to) the projects directory object
 
         No setter is provided.
@@ -137,7 +137,7 @@ class ProjectSelection:
 
     @property
     def using_save_as(self) -> bool:
-        """Flag indicating if the next model shoudl be copied from the current model or not."""
+        """Flag indicating if the next model should be copied from the current model or not."""
         return self.__using_save_as
 
     @using_save_as.setter
@@ -177,11 +177,11 @@ class ProjectSelection:
 
         # Get the existing or new project.
         # Any raised exceptions will be allowed to propagate upwards for presentation to the user
-        project = self.projects_directiory.get_or_create_project(self.next_project_name)
+        project = self.projects_directory.get_or_create_project(self.next_project_name)
 
         # Within that Project, get or create the model.
         # Any raised exceptions will be allowed to propagate upwards for presentation to the user
-        # Depedning on function parameters, try to load or create the model
+        # Depending on function parameters, try to load or create the model
         if load_ok and create_ok:
             project.get_or_create_model(self.next_model_name, copy_from)
         elif load_ok and not create_ok:
@@ -193,7 +193,7 @@ class ProjectSelection:
             function_name = inspect.currentframe().f_code.co_name
             raise ValueError(f"{function_name} requires at least one of 'load_ok' and 'create_ok' to be True")
 
-        # Update internal state, setting the current and next project/model variables, if no exceptions occured so far
+        # Update internal state, setting the current and next project/model variables, if no exceptions occurred so far
         self.current_project_name = self.next_project_name
         self.current_model_name = self.next_model_name
         self.next_project_name = None

--- a/src/polychron/models/ProjectsDirectory.py
+++ b/src/polychron/models/ProjectsDirectory.py
@@ -11,7 +11,7 @@ class ProjectsDirectory:
     """MVP Model representing the projects directory"""
 
     path: pathlib.Path
-    """path to the projects direcotry this objet reprsents"""
+    """path to the projects directory this objet represents"""
 
     projects: dict[str, Project] = field(default_factory=dict)
     """projects within the projects directory"""

--- a/src/polychron/presenters/CalibrateModelSelectPresenter.py
+++ b/src/polychron/presenters/CalibrateModelSelectPresenter.py
@@ -7,7 +7,7 @@ from .PopupPresenter import PopupPresenter
 class CalibrateModelSelectPresenter(PopupPresenter[CalibrateModelSelectView, ProjectSelection]):
     """Presenter for selecting which models to calibrate, when multiple models are to be calibrated at once.
 
-    Formerly `popupWindow8`, used from "tool > Calibrate multiple projects from project"
+    Formerly `popupWindow8`, used from "tool > Calibrate multiple models from project"
     """
 
     def __init__(self, mediator: Mediator, view: CalibrateModelSelectView, model: ProjectSelection) -> None:

--- a/src/polychron/presenters/ModelCreatePresenter.py
+++ b/src/polychron/presenters/ModelCreatePresenter.py
@@ -9,7 +9,7 @@ from .FramePresenter import FramePresenter
 
 class ModelCreatePresenter(FramePresenter[ModelCreateView, ProjectSelection]):
     def __init__(self, mediator: Mediator, view: ModelCreateView, model: ProjectSelection) -> None:
-        # Call the parent class' consturctor
+        # Call the parent class' constructor
         super().__init__(mediator, view, model)
 
         # Bind button callbacks to presenter methods
@@ -34,10 +34,10 @@ class ModelCreatePresenter(FramePresenter[ModelCreateView, ProjectSelection]):
                 self.model.switch_to_next_project_model(load_ok=False, create_ok=True)
             except RuntimeError as e:
                 # Runtime errors currently include existing directories (and missing values)
-                messagebox.showerror("Tips", f"An error occured while creating the model: {e}", parent=self.view)
+                messagebox.showerror("Tips", f"An error occurred while creating the model: {e}", parent=self.view)
             except Exception as e:
                 # Other exceptions may occur, i.e. permission errors. Forward the message to the user.
-                messagebox.showerror("Tips", f"An error occured while creating the model: {e}", parent=self.view)
+                messagebox.showerror("Tips", f"An error occurred while creating the model: {e}", parent=self.view)
             else:
                 # If no exceptions occurred, and the model has been created (and it's folders) present a succes message and close the popup.
                 messagebox.showinfo("Tips:", "model created successfully!", parent=self.view)
@@ -49,7 +49,7 @@ class ModelCreatePresenter(FramePresenter[ModelCreateView, ProjectSelection]):
     def on_back_button(self) -> None:
         """When the back button is pressed, return to the previous view
 
-        This behaves differntly than polychron 0.1, by returning to the previous view rather than always new project creation"""
+        This behaves differently than polychron 0.1, by returning to the previous view rather than always new project creation"""
         # Clear any value from the the models new_model property
         self.model.next_model_name = None
         # If we came from project_create, return to it. Otherwise return to model_select

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -97,7 +97,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
             [
                 ("Render chronological graph", lambda: self.chronograph_render_wrap()),
                 ("Calibrate model", lambda: self.popup_calibrate_model()),
-                ("Calibrate multiple projects from project", lambda: self.popup_calibrate_multiple()),
+                ("Calibrate multiple models from project", lambda: self.popup_calibrate_multiple()),
                 # ("Calibrate node delete variations (alpha)",  lambda: self.calibrate_node_delete_variations()), # see https://github.com/bryonymoody/PolyChron/issues/71
                 # ("Calibrate important variations (alpha)",  lambda: self.calibrate_important_variations()), # see https://github.com/bryonymoody/PolyChron/issues/72
             ]
@@ -194,7 +194,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         self.mediator.switch_presenter("DatingResults")
 
     def popup_calibrate_multiple(self) -> None:
-        """Callback function for when Tools -> Calibrate multiple projects from project is selected
+        """Callback function for when Tools -> Calibrate multiple models from project is selected
 
         Opens a new popup box allowing the user to select which models from a list to calibrate as a batch.
 

--- a/src/polychron/presenters/ProjectSelectPresenter.py
+++ b/src/polychron/presenters/ProjectSelectPresenter.py
@@ -20,7 +20,7 @@ class ProjectSelectPresenter(FramePresenter[ProjectSelectView, ProjectSelection]
 
     def update_view(self) -> None:
         """Update text & tables within the view to reflect the current state of the model"""
-        project_names = list(self.model.projects_directiory.projects.keys())
+        project_names = list(self.model.projects_directory.projects.keys())
         self.view.update_project_list(project_names)
 
     def on_load_button(self) -> None:

--- a/src/polychron/presenters/ProjectWelcomePresenter.py
+++ b/src/polychron/presenters/ProjectWelcomePresenter.py
@@ -23,7 +23,7 @@ class ProjectWelcomePresenter(FramePresenter[ProjectWelcomeView, ProjectSelectio
     def on_load_button(self) -> None:
         """When the load button is pressed, update the SelectProject view and switch to it"""
         # Update the list of available projects from disk (in case any have been created since)
-        self.model.projects_directiory.lazy_load()
+        self.model.projects_directory.lazy_load()
         self.mediator.switch_presenter("project_select")
 
     def on_create_button(self) -> None:

--- a/src/polychron/presenters/ResidualOrIntrusivePresenter.py
+++ b/src/polychron/presenters/ResidualOrIntrusivePresenter.py
@@ -22,7 +22,7 @@ class ResidualOrIntrusivePresenter(PopupPresenter[ResidualOrIntrusiveView, Model
     """
 
     def __init__(self, mediator: Mediator, view: ResidualOrIntrusiveView, model: Model) -> None:
-        # Call the parent class' consturctor
+        # Call the parent class' constructor
         super().__init__(mediator, view, model)
 
         self.mode: Literal["resid", "intru"] | None = None

--- a/src/polychron/presenters/SplashPresenter.py
+++ b/src/polychron/presenters/SplashPresenter.py
@@ -11,11 +11,11 @@ from .ProjectSelectProcessPopupPresenter import ProjectSelectProcessPopupPresent
 class SplashPresenter(FramePresenter[SplashView, ProjectSelection]):
     """Presenter for the Splash Frame, shown in the main view before a project has been loaded.
 
-    This exists soley to allow users who close the initial project selection page to re-open it.
+    This exists solely to allow users who close the initial project selection page to re-open it.
     """
 
     def __init__(self, mediator: Mediator, view: SplashView, model: ProjectSelection) -> None:
-        # Call the parent class' consturctor
+        # Call the parent class' constructor
         super().__init__(mediator, view, model)
 
         self.child_presenter: ProjectSelectProcessPopupPresenter | None = None
@@ -33,7 +33,7 @@ class SplashPresenter(FramePresenter[SplashView, ProjectSelection]):
         pass
 
     def on_select_project(self) -> None:
-        """Function which is called when File > Select Project is selected. I.e. open the popup preesnter for selecting a project."""
+        """Function which is called when File > Select Project is selected. I.e. open the popup presenter for selecting a project."""
 
         # Instantiate the child presenter and view
         popup_presenter = ProjectSelectProcessPopupPresenter(

--- a/src/polychron/views/CalibrateModelSelectView.py
+++ b/src/polychron/views/CalibrateModelSelectView.py
@@ -9,7 +9,7 @@ from .PopupView import PopupView
 class CalibrateModelSelectView(PopupView):
     """View for selecting which models to calibrate, when multiple models are to be calibrated at once
 
-    Formerly `popupWindow8`, used from menu option "Calibrate multiple projects from project"
+    Formerly `popupWindow8`, used from menu option "Calibrate multiple models from project"
     """
 
     def __init__(self, parent: tk.Frame) -> None:


### PR DESCRIPTION
Changed "Calibrate multiple projects from project" to "Calibrate multiple models from project".
Fixed typos I found whilst searching for the line above. 
Closes #165 