### PR TITLE
DatingResults: Use a dictionary for the results_list for insertion-order preserving unique element checking

### DIFF
--- a/src/polychron/views/DatingResultsView.py
+++ b/src/polychron/views/DatingResultsView.py
@@ -556,13 +556,14 @@ class DatingResultsView(FrameView):
         """Update the contents of littlecanvas3
 
         Formerly part of PageOne.chornograph_render_post
+
+        Parameters:
+            results_list: a ordered list of (unique) node labels
         """
         self.clear_littlecanvas3()
-        cont_canvas_list = ""
-        for i in set(results_list):
-            cont_canvas_list = cont_canvas_list + str(i) + "\n"
+        canvas_list = "\n".join(results_list)
         self.results_text = self.littlecanvas3.create_text(
-            5, 10, anchor="nw", text=cont_canvas_list, fill="#0A3200", font=("Helvetica 12 bold")
+            5, 10, anchor="nw", text=canvas_list, fill="#0A3200", font=("Helvetica 12 bold")
         )
 
     def show_canvas_plot(self, fig: Figure) -> None:

--- a/tests/polychron/presenters/test_DatingResultsPresenter.py
+++ b/tests/polychron/presenters/test_DatingResultsPresenter.py
@@ -62,7 +62,7 @@ class TestDatingResultsPresenter:
         assert presenter.model == model
 
         # Assert that the presenter properties are initialsed as expected
-        assert presenter.results_list == []
+        assert presenter.results_list == {}
         assert presenter.node == "no node"
         assert presenter.phase_len_nodes == []
         assert presenter.fig is None
@@ -530,9 +530,19 @@ class TestDatingResultsPresenter:
 
         # The results list should not be empty
         assert len(presenter.results_list) != 0
+        assert list(presenter.results_list.keys()) == ["foo"]
 
         # view.clear_littlecanvas3 should have been called
         mock_view.clear_littlecanvas3.assert_called_once()
+
+        # ---
+        # The list should only contain unique elements, and as a dictionary is used the key order (in python 3.7+) is insertion order preserving.
+        # So add multiple elements, including duplicates and check the contents are as expected
+        insertions = ["foo", "foo", "bar", "foo", "baz", "bar", "bar", "bar"]
+        for i in insertions:
+            presenter.node = i
+            presenter.testmenu_add_to_results_list()
+        assert list(presenter.results_list.keys()) == ["foo", "bar", "baz"]
 
     @pytest.mark.skip(reason="test_testmenu_get_time_elapsed_between not implemented, includes tkinter")
     def test_testmenu_get_time_elapsed_between(self):


### PR DESCRIPTION
Use a dictionary for the results_list for insertion-order preserving unique element checking

The previous use of a set to remove duplicates lost the insertion order when displaying the list, and resulted in the plot order potentially not matching up.

Closes #161
