### PR TITLE
Fix: Preview Datafiles in the same order as the source file

### DIFF
--- a/src/polychron/views/DatafilePreviewView.py
+++ b/src/polychron/views/DatafilePreviewView.py
@@ -62,4 +62,4 @@ class DatafilePreviewView(PopupView):
             self.tree.column(i, anchor="w")
             self.tree.heading(i, text=i, anchor="w")
         for index, row in rows:
-            self.tree.insert("", 00, text=index, values=row)
+            self.tree.insert("", "end", text=index, values=row)


### PR DESCRIPTION
Preview Datafiles in the same order as the source file

Closes #141

---

I.e. for

```csv
above,below
a,b
b,c
b,d
b,e
d,f
e,g
```

Would previously be previewed as:

<img width="544" height="478" alt="image" src="https://github.com/user-attachments/assets/dc0e1ed0-3f9d-4c59-835b-5d14051e2525" />


But is now previewed as:

<img width="544" height="478" alt="image" src="https://github.com/user-attachments/assets/00420cbf-5914-44ed-a018-b65dc05ae7bd" />
