### PR TITLE
Dating Results: Improve handling of the 2 types of plots

### DIFF
--- a/src/polychron/presenters/DatingResultsPresenter.py
+++ b/src/polychron/presenters/DatingResultsPresenter.py
@@ -342,7 +342,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
         # plot1.set_xlim([0, 400])
         plot1.title.set_text(f"Time elapsed between {self.phase_len_nodes[0]} and {self.phase_len_nodes[1]}")
         # self.fig.set_tight_layout(True)
-        self.view.show_canvas_plot(self.fig)
+        self.view.show_canvas_plot_with_toolbar(self.fig)
         # show hpd intervals
         interval = list(HPD_interval(np.array(lengths[1000:])))
         intervals = []

--- a/src/polychron/views/DatingResultsView.py
+++ b/src/polychron/views/DatingResultsView.py
@@ -566,17 +566,19 @@ class DatingResultsView(FrameView):
             5, 10, anchor="nw", text=canvas_list, fill="#0A3200", font=("Helvetica 12 bold")
         )
 
-    def show_canvas_plot(self, fig: Figure) -> None:
-        """Add (or reaplce) the visible plot with the provided figure"""
-        self.canvas_plt = FigureCanvasTkAgg(fig, master=self.littlecanvas)
-        self.canvas_plt.get_tk_widget().place(relx=0, rely=0, relwidth=1)
-        self.canvas_plt.draw_idle()
-
     def show_canvas_plot_with_toolbar(self, fig: Figure) -> None:
-        """Add (or reaplce) the visible plot with the provided figure"""
+        """Add (or replace) the visible plot with the provided figure
+
+        Parameters:
+            fig: The matplotlib Figure to be displayed in the interactive canvas
+        """
+        # Construct a matplotlib figure canvas using the tkinter agg backend
         self.canvas_plt = FigureCanvasTkAgg(fig, master=self.littlecanvas)
         self.canvas_plt.draw()
-        # creating the Matplotlib toolbar
-        self.toolbar = NavigationToolbar2Tk(self.canvas_plt, self.littlecanvas)
+        # Create the Matplotlib toolbar
+        self.toolbar = NavigationToolbar2Tk(self.canvas_plt, self.littlecanvas, pack_toolbar=False)
         self.toolbar.update()
-        self.canvas_plt.get_tk_widget().pack()
+        # Pack the toolbar below the figure
+        self.toolbar.pack(side=tk.BOTTOM, fill=tk.X)
+        # Pack the canvas plot tk widget into the littlecanvas, filling in both directions. expand=true could be used instead if the plots being reshaped to fill the space is desirable
+        self.canvas_plt.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH)


### PR DESCRIPTION
Improve handling of the 2 types of plots

- Both types of plots are now bound to the toolbar. Closes #156
- Uses pack for both plots, not a mix of place and pack, preventing the date range plots being visible underneath the posterior densities plot. Closes #160
- By using the same packing technique for both plots, the clear list button also clears both types of plot. Closes #159