### PR TITLE
Context grouping: use 'group' not 'Group' for csv column name

### DIFF
--- a/src/polychron/models/MCMCData.py
+++ b/src/polychron/models/MCMCData.py
@@ -102,7 +102,7 @@ class MCMCData:
         df.to_csv(full_results_df_path, index=False)
 
         # List containing the the group for each context, in order of topologically sorted contexts.
-        key_ref = [list(group_df["Group"])[list(group_df["context"]).index(i)] for i in self.contexts]
+        key_ref = [list(group_df["group"])[list(group_df["context"]).index(i)] for i in self.contexts]
         df1 = pd.DataFrame(key_ref)
         df1.to_csv(path / "key_ref.csv", index=False)
 

--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -89,7 +89,7 @@ class Model:
     group_df: Optional[pd.DataFrame] = field(default=None)
     """Dataframe of context grouping information loaded from disk. 
 
-    Expected columns ["context", "Group"]
+    Expected columns ["context", "group"]
     
     Formerly `StartPage.phasefile`
     """
@@ -537,6 +537,12 @@ class Model:
             if "group_relationship_df" in model_data and model_data["group_relationship_df"] is not None:
                 model_data["group_relationship_df"] = model_data["group_relationship_df"].astype(str)
 
+            # Fixup column names, for dataframes which have had their column names changed compared to older PolyChron versions.
+            if "group_df" in model_data and model_data["group_df"] is not None:
+                df = model_data["group_df"]
+                if "group" not in df and "Group" in df:
+                    model_data["group_df"] = df.rename(columns={"Group": "group"})
+
             # Overwrite certain elements, i.e the path (in case the model fields have been copied), but the path was included in the save file
             if "name" not in model_data:
                 model_data["name"] = str(path.name)
@@ -700,7 +706,7 @@ class Model:
         # Post processing of the dataframe
         if self.stratigraphic_dag:
             for i, j in enumerate(self.group_df["context"]):
-                self.stratigraphic_dag.nodes()[str(j)].update({"Group": self.group_df["Group"][i]})
+                self.stratigraphic_dag.nodes()[str(j)].update({"Group": self.group_df["group"][i]})
 
     def set_group_relationship_df(self, df: pd.DataFrame) -> None:
         """Provided a dataframe for group relationships information, set the values locally and post-process
@@ -1052,7 +1058,7 @@ class Model:
         topo_sort.reverse()
         context_no = topo_sort
         # Get a list containing the group per context (in reverse topological order)
-        key_ref = [list(self.group_df["Group"])[list(self.group_df["context"]).index(i)] for i in context_no]
+        key_ref = [list(self.group_df["group"])[list(self.group_df["context"]).index(i)] for i in context_no]
         self.context_types = [self.context_types[list(self.context_no_unordered).index(i)] for i in topo_sort]
         strat_vec = []
         resids = [j for i, j in enumerate(context_no) if self.context_types[i] == "residual"]

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -433,18 +433,19 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         if file is not None:
             try:
                 model_model = self.model.current_model
-                df = pd.read_csv(file)
-                df = df.astype(str)
+                df = pd.read_csv(file, dtype=str)
+                if "context" not in df.columns:
+                    raise ValueError("'context' is a required column for group relationship files")
+                if "group" not in df.columns:
+                    raise ValueError("'group' is a required column for group relationship files")
                 load_it = self.file_popup(df)
                 if load_it == "load":
                     model_model.set_group_df(df)
                     self.phase_check = True
                     self.check_list_gen()
                     self.view.messagebox_info("Success", "Grouping data loaded")
-                else:
-                    pass
-            except ValueError:
-                self.view.messagebox_error("Error", "Data not loaded, please try again")
+            except ValueError as e:
+                self.view.messagebox_error("Error", f"Data not loaded, please try again:\n\n{e}")
 
     def open_group_relationship_file(self) -> None:
         """Callback function when File > Load group relationship file (.csv) is selected, opening a group relationship / phase relationship file

--- a/tests/data/context-grouping-csv/extra-columns.csv
+++ b/tests/data/context-grouping-csv/extra-columns.csv
@@ -1,4 +1,4 @@
-context,Group,foo,bar
+context,group,foo,bar
 a,2,foo,bar
 b,2,foo,bar
 c,1,foo,bar

--- a/tests/data/context-grouping-csv/header-only.csv
+++ b/tests/data/context-grouping-csv/header-only.csv
@@ -1,1 +1,1 @@
-context,Group
+context,group

--- a/tests/data/context-grouping-csv/simple.csv
+++ b/tests/data/context-grouping-csv/simple.csv
@@ -1,4 +1,4 @@
-context,Group
+context,group
 a,3
 b,2
 c,1

--- a/tests/data/demo/3-context-grouping.csv
+++ b/tests/data/demo/3-context-grouping.csv
@@ -1,4 +1,4 @@
-context,Group
+context,group
 a,2
 b,2
 c,1

--- a/tests/data/many-groups/3-context-grouping.csv
+++ b/tests/data/many-groups/3-context-grouping.csv
@@ -1,4 +1,4 @@
-context,Group
+context,group
 a,group_a
 b,foo
 c,bar

--- a/tests/data/thesis/thesis-b3-context-grouping.csv
+++ b/tests/data/thesis/thesis-b3-context-grouping.csv
@@ -1,4 +1,4 @@
-context,Group
+context,group
 758,1
 814,1
 1235,1

--- a/tests/polychron/models/test_MCMCData.py
+++ b/tests/polychron/models/test_MCMCData.py
@@ -220,7 +220,7 @@ class TestMCMCData:
         obj.all_group_limits = all_group_limits
 
         # Prepare method input data
-        group_df = pd.DataFrame({"context": contexts, "Group": ["1", "2", "1"]})
+        group_df = pd.DataFrame({"context": contexts, "group": ["1", "2", "1"]})
 
         # Call save_results_dataframes
         obj.save_results_dataframes(tmp_path, group_df)
@@ -379,7 +379,7 @@ class TestMCMCData:
             accept_group_limits=accept_group_limits,
             all_group_limits=all_group_limits,
         )
-        group_df = pd.DataFrame({"context": contexts, "Group": ["1", "2", "1"]})
+        group_df = pd.DataFrame({"context": contexts, "group": ["1", "2", "1"]})
 
         # Save the instance
         obj.save(tmp_path, group_df)

--- a/tests/polychron/models/test_Model.py
+++ b/tests/polychron/models/test_Model.py
@@ -457,12 +457,12 @@ class TestModel:
             # Valid dataframe, with changes
             ("context-grouping-csv/simple.csv", 4, None),
             # Dataframe with partial information
-            ({"context": ["a", "b"], "Group": [1, 2]}, 2, None),
+            ({"context": ["a", "b"], "group": [1, 2]}, 2, None),
             # Dataframe with unknown context
             pytest.param(
                 {
                     "context": ["a", "b", "c", "d", "e"],
-                    "Group": [1, 2, 1, 2, 1],
+                    "group": [1, 2, 1, 2, 1],
                 },
                 4,
                 None,

--- a/tests/polychron/presenters/test_ModelPresenter.py
+++ b/tests/polychron/presenters/test_ModelPresenter.py
@@ -737,16 +737,8 @@ class TestModelPresenter:
             ("strat-csv/simple.csv", "context-grouping-csv/empty.csv", "load", False, True, 0),
             # A csv file with no rows. This is currently accepted but should not be.
             ("strat-csv/simple.csv", "context-grouping-csv/header-only.csv", "load", True, False, 0),
-            # A csv with the incorrect column names. This currently raises an uncaught exception
-            pytest.param(
-                "strat-csv/simple.csv",
-                "context-grouping-csv/bad-column-names.csv",
-                "load",
-                False,
-                True,
-                0,
-                marks=pytest.mark.xfail(reason="bad column names are not handled gracefully in set_group_df"),
-            ),
+            # A csv with the incorrect column names.
+            ("strat-csv/simple.csv", "context-grouping-csv/bad-column-names.csv", "load", False, True, 0),
             # A csv with extra columns, which are not used
             ("strat-csv/simple.csv", "context-grouping-csv/extra-columns.csv", "load", True, False, 4),
         ],


### PR DESCRIPTION
Context grouping: use 'group' not 'Group' for csv column name, and fixup old polychron save files on load

Part of #106