### PR TITLE
Fix: Fix saving and calibrating models after GroupRelationship Enum was added

### DIFF
--- a/src/polychron/models/GroupRelationship.py
+++ b/src/polychron/models/GroupRelationship.py
@@ -35,6 +35,13 @@ class GroupRelationship(Enum):
         # Otherwise fall back to the other object
         return NotImplemented
 
+    def __hash__(self) -> int:
+        """Custom hash implementation, which must be overridden when __eq__ is overridden.
+
+        Returns: default hash implementation of the underlying string value
+        """
+        return hash(self.value)
+
     @classmethod
     def from_string(cls, value: str) -> "GroupRelationship":
         """Converts a string into a GroupRelationship enum

--- a/src/polychron/presenters/ManageGroupRelationshipsPresenter.py
+++ b/src/polychron/presenters/ManageGroupRelationshipsPresenter.py
@@ -445,8 +445,8 @@ class ManageGroupRelationshipsPresenter(PopupPresenter[ManageGroupRelationshipsV
 
         # Update other model properties
         self.model.context_types = self.context_types
-        self.model.prev_group = prev_group
-        self.model.post_group = post_group
+        self.model.prev_group = [str(x) for x in prev_group]
+        self.model.post_group = [str(x) for x in post_group]
         self.model.phi_ref = phi_ref
         self.model.context_no_unordered = self.context_no_unordered
         self.model.removed_nodes_tracker = self.removed_nodes_tracker

--- a/tests/polychron/models/test_GroupRelationship.py
+++ b/tests/polychron/models/test_GroupRelationship.py
@@ -70,6 +70,16 @@ class TestGroupRelationship:
         result = a == b
         assert expected == result
 
+    def test_hash(self):
+        """Test that the Group Relationship enum can be hashed, by using as a dictionary key"""
+        d = {}
+        d[GroupRelationship.ABUTTING] = "abutting"
+        assert GroupRelationship.ABUTTING in d
+        d[GroupRelationship.GAP] = "gap"
+        assert GroupRelationship.GAP in d
+        d[GroupRelationship.OVERLAP] = "overlap"
+        assert GroupRelationship.OVERLAP in d
+
     @pytest.mark.parametrize(
         ("value", "expected"),
         [


### PR DESCRIPTION
In #232 I introduced an enum `GroupRelationship`, to reduce duplication of string literals.

This prevented saving and calibration from functioning, as the enum was not hashable, and was not json serialisable. 

This makes it hashable by implementing and testing `__hash__`, but also ensures that the enums are re-converted to strings prior to storing in the `Model`.

It might not be worth using the Enum, as it adds complexity. Namespaced constants might be a much simpler alternative