### PR TITLE
PyPI fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To create a new PolyChron release:
 
 1. Ensure that the `HEAD` of `main` is in a good working state, ready for wider release. This should include making sure that package metadata in `pyproject.toml` is correct and all CI checks pass.
     - PolyChron is following [Semantic Versioning](https://semver.org/) and as the version number should comply with [PEP 440](https://peps.python.org/pep-0440/)
-2. Tag the commit which is intended for release, using the version included in `pyproject.toml` prefixed with `v` (e.g. `v0.2.0`, `v1.2.3rc1`).
+2. Tag the commit which is intended for release, using the version included in `pyproject.toml` prefixed with `v` (e.g. `v0.2.1`, `v1.2.3rc1`).
 3. [Create a Release](https://github.com/bryonymoody/PolyChron/releases/new) in GitHub, using the newly pushed tag, providing some Release Notes.
   - On tag push, starting with `v`, `.github/workflows/publish.yml` should upload the new version to [PyPI](https://pypi.org/)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PolyChron
 
-![PolyChron Logo](./src/polychron/resources/logo.png)
+![PolyChron Logo](https://raw.githubusercontent.com/bryonymoody/PolyChron/refs/heads/main/src/polychron/resources/logo.png)
 
 [![Tests](https://github.com/bryonymoody/PolyChron/actions/workflows/tests.yml/badge.svg)](https://github.com/bryonymoody/PolyChron/actions/workflows/tests.yml)
 [![Docs](https://github.com/bryonymoody/PolyChron/actions/workflows/docs.yml/badge.svg)](https://github.com/bryonymoody/PolyChron/actions/workflows/docs.yml)

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ source .venv/bin/activate
 ```bash
 # Install the current development version
 python3 -m pip install git+https://github.com/bryonymoody/PolyChron.git
-# Install a tagged release or branch, in this case v0.2.0
-python3 -m pip install git+https://github.com/bryonymoody/PolyChron.git@v0.2.0
+# Install a tagged release or branch, in this case v0.2.1
+python3 -m pip install git+https://github.com/bryonymoody/PolyChron.git@v0.2.1
 ```
 
 Or by cloning the `git` repository from [GitHub](https://github.com/bryonymoody/PolyChron) and installing into the current python environment.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,10 +88,10 @@ python3 -m pip install polychron
     python3 -m pip install git+https://github.com/bryonymoody/PolyChron.git
     ```
 
-=== "v0.2.0"
+=== "v0.2.1"
 
     ```bash
-    python3 -m pip install git+https://github.com/bryonymoody/PolyChron.git@v0.2.0
+    python3 -m pip install git+https://github.com/bryonymoody/PolyChron.git@v0.2.1
     ```
 
 Or by cloning the `git` repository from [GitHub](https://github.com/bryonymoody/PolyChron) and installing into the current python environment.

--- a/src/polychron/_version.py
+++ b/src/polychron/_version.py
@@ -21,7 +21,7 @@ def is_editable_install() -> bool:
         direct_url = json.loads(distribution.read_text("direct_url.json"))
         is_editable = direct_url.get("dir_info", {}).get("editable", False)
         return is_editable
-    except importlib.metadata.PackageNotFoundError:
+    except Exception:
         return False
 
 
@@ -66,7 +66,7 @@ def get_local_install_git_hash() -> str | None:
 
         return git_hash
 
-    except subprocess.CalledProcessError:
+    except Exception:
         return None
 
 

--- a/src/polychron/_version.py
+++ b/src/polychron/_version.py
@@ -6,7 +6,7 @@ import subprocess
 from pathlib import Path
 
 # Define the public version string
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 def is_editable_install() -> bool:

--- a/src/polychron/models/MCMCData.py
+++ b/src/polychron/models/MCMCData.py
@@ -213,7 +213,7 @@ class MCMCData:
 
             # Any polychron-version specific handling of data
             polychron_version = data["polychron_version"]
-            if polychron_version == "0.2.0":
+            if polychron_version == "0.2.1":
                 pass
 
             # Convert certain values back based on the hint for the data type.


### PR DESCRIPTION
Several fixes for pypi release

- Bump version number to 0.2.1
- Improve robustness of editable version checking, as the `direct_url.json` is not included when instlaling from pypi (but is from local wheel installations)
- Use an absolute URI for the logo in the readme, so it is correctly linked to by pypi