### PR TITLE
Add mcmc seed selection

### DIFF
--- a/src/polychron/mcmc.py
+++ b/src/polychron/mcmc.py
@@ -1466,6 +1466,7 @@ def run_MCMC(
 
     if seed is not None:
         np.random.seed(seed)
+        random.seed(seed)
 
     #  t0 = time.perf_counter()
     PHI_SAMP_DICT = {

--- a/src/polychron/mcmc.py
+++ b/src/polychron/mcmc.py
@@ -1459,7 +1459,7 @@ def run_MCMC(
     POST_PHASE,
     TOPO_SORT,
     CONT_TYPE,
-    seed,
+    seed=None,
     PROGRESS_IO: Writable | None = None,
 ):
     """Run the MCMC algorithm for a set of input data from a Model, returning the tuple of results"""

--- a/src/polychron/mcmc.py
+++ b/src/polychron/mcmc.py
@@ -1459,8 +1459,8 @@ def run_MCMC(
     POST_PHASE,
     TOPO_SORT,
     CONT_TYPE,
+    seed,
     PROGRESS_IO: Writable | None = None,
-    seed=None,
 ):
     """Run the MCMC algorithm for a set of input data from a Model, returning the tuple of results"""
 

--- a/src/polychron/mcmc.py
+++ b/src/polychron/mcmc.py
@@ -1460,8 +1460,13 @@ def run_MCMC(
     TOPO_SORT,
     CONT_TYPE,
     PROGRESS_IO: Writable | None = None,
+    seed=None,
 ):
     """Run the MCMC algorithm for a set of input data from a Model, returning the tuple of results"""
+
+    if seed is not None:
+        np.random.seed(seed)
+
     #  t0 = time.perf_counter()
     PHI_SAMP_DICT = {
         "upper": {

--- a/src/polychron/mcmc.py
+++ b/src/polychron/mcmc.py
@@ -1459,13 +1459,9 @@ def run_MCMC(
     POST_PHASE,
     TOPO_SORT,
     CONT_TYPE,
-    seed,
     PROGRESS_IO: Writable | None = None,
 ):
     """Run the MCMC algorithm for a set of input data from a Model, returning the tuple of results"""
-
-    np.random.seed(seed)
-    random.seed(seed)
 
     #  t0 = time.perf_counter()
     PHI_SAMP_DICT = {

--- a/src/polychron/mcmc.py
+++ b/src/polychron/mcmc.py
@@ -1459,14 +1459,13 @@ def run_MCMC(
     POST_PHASE,
     TOPO_SORT,
     CONT_TYPE,
-    seed=None,
+    seed,
     PROGRESS_IO: Writable | None = None,
 ):
     """Run the MCMC algorithm for a set of input data from a Model, returning the tuple of results"""
 
-    if seed is not None:
-        np.random.seed(seed)
-        random.seed(seed)
+    np.random.seed(seed)
+    random.seed(seed)
 
     #  t0 = time.perf_counter()
     PHI_SAMP_DICT = {

--- a/src/polychron/models/MCMCData.py
+++ b/src/polychron/models/MCMCData.py
@@ -1,7 +1,7 @@
 import json
 import pathlib
 from dataclasses import dataclass, field
-from typing import Dict, List, get_type_hints
+from typing import Dict, List, Optional, get_type_hints
 
 import pandas as pd
 from packaging.version import Version
@@ -80,6 +80,9 @@ class MCMCData:
 
     calibration_curve_name: str = "intcal20_interpolated"
     """Name of the calibration curve which was used to generate this `MCMCData`. This enables the correct curve to be displayed on the dating results tab when the curve has been changed, but the model has not been re-calibrated."""
+
+    seed: Optional[int] = None
+    """Seed used for the current MCMC run. None indicates a random seed will be generated."""
 
     def save_results_dataframes(self, path: pathlib.Path, group_df: pd.DataFrame) -> None:
         """Save some MCMC data to disk, separately from the serialised version of this class

--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -5,6 +5,7 @@ import filecmp
 import json
 import os
 import pathlib
+import random
 import shutil
 import sys
 from dataclasses import dataclass, field
@@ -1019,7 +1020,7 @@ class Model:
         return self.__calibration
 
     def MCMC_func(
-        self, progress_io: Optional[Writable]
+        self, progress_io: Optional[Writable] = None
     ) -> Tuple[
         List[str],
         List[List[float]],
@@ -1044,11 +1045,6 @@ class Model:
 
         Formerly `StartPage.MCMC_func`
         """
-
-        seed = self.seed
-        if seed is None:
-            seed = np.random.randint(0, 2**32 - 1)
-            self.seed = seed
 
         if not self.is_ready_for_mcmc():
             raise RuntimeError("Model is not MCMC ready, the stratigraphic and chronographic dag are not valid")
@@ -1128,7 +1124,6 @@ class Model:
             self.post_group,
             topo_sort,
             self.context_types,
-            seed,
             progress_io,
         )
         _, accept_group_limits, all_group_limits = phase_labels(phi_ref, self.post_group, phi_accept, all_samples_phi)
@@ -1149,3 +1144,19 @@ class Model:
             accept_group_limits,
             all_group_limits,
         )
+
+    def apply_seed(self, seed: Optional[int]):
+        """Seed the RNGs used during MCMC.
+        If seed is None, a new random seed is generated and stored as self.model.seed."""
+        if seed is None:
+            # reset random state
+            np.random.seed(None)
+            # generate a fresh random seed
+            seed = np.random.randint(0, 2**32 - 1)
+
+        # seed numpy
+        np.random.seed(seed)
+        # seed ranomd with a slightly diff seed
+        random.seed(seed + 1)
+        # store the seed
+        self.seed = seed

--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -1018,14 +1018,6 @@ class Model:
         """Get the currently selected calibration curve (if any)."""
         return self.__calibration
 
-    def set_seed(self, seed: Optional[int]) -> None:
-        """Set the seed used for the current MCMC run."""
-        self.seed = seed
-
-    def get_seed(self) -> Optional[int]:
-        """Get the seed used for the current MCMC run."""
-        return self.seed
-
     def MCMC_func(
         self, progress_io: Optional[Writable]
     ) -> Tuple[
@@ -1057,7 +1049,6 @@ class Model:
         if seed is None:
             seed = np.random.randint(0, 2**32 - 1)
             self.seed = seed
-            self.view.set_seedlabel(seed)
 
         if not self.is_ready_for_mcmc():
             raise RuntimeError("Model is not MCMC ready, the stratigraphic and chronographic dag are not valid")

--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -1152,7 +1152,7 @@ class Model:
             # reset random state
             np.random.seed(None)
             # generate a fresh random seed
-            seed = np.random.randint(0, 2**32 - 1)
+            seed = np.random.randint(0, 2**31 - 1)
 
         # seed numpy
         np.random.seed(seed)

--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -12,6 +12,7 @@ from inspect import signature
 from typing import Dict, List, Literal, Optional, Tuple, get_type_hints
 
 import networkx as nx
+import numpy as np
 import packaging.version
 import pandas as pd
 import pydot
@@ -1017,6 +1018,14 @@ class Model:
         """Get the currently selected calibration curve (if any)."""
         return self.__calibration
 
+    def set_seed(self, seed: Optional[int]) -> None:
+        """Set the seed used for the current MCMC run."""
+        self.seed = seed
+
+    def get_seed(self) -> Optional[int]:
+        """Get the seed used for the current MCMC run."""
+        return self.seed
+
     def MCMC_func(
         self, progress_io: Optional[Writable]
     ) -> Tuple[
@@ -1043,6 +1052,12 @@ class Model:
 
         Formerly `StartPage.MCMC_func`
         """
+
+        seed = self.seed
+        if seed is None:
+            seed = np.random.randint(0, 2**32 - 1)
+            self.seed = seed
+            self.view.set_seedlabel(seed)
 
         if not self.is_ready_for_mcmc():
             raise RuntimeError("Model is not MCMC ready, the stratigraphic and chronographic dag are not valid")
@@ -1122,6 +1137,7 @@ class Model:
             self.post_group,
             topo_sort,
             self.context_types,
+            seed,
             progress_io,
         )
         _, accept_group_limits, all_group_limits = phase_labels(phi_ref, self.post_group, phi_accept, all_samples_phi)

--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -273,7 +273,7 @@ class Model:
     __calibration: Optional[InterpolatedRCDCalibrationCurve] = field(default=None, init=False, repr=False)
     """Interpolated RCD calibration curve object, which is stored in a member variable so it is loaded once and only once"""
 
-    current_seed: Optional[int] = None
+    seed: Optional[int] = None
     """Seed used for the current MCMC run. None indicates a random seed will be generated."""
 
     def get_working_directory(self) -> pathlib.Path:

--- a/src/polychron/models/Model.py
+++ b/src/polychron/models/Model.py
@@ -273,6 +273,9 @@ class Model:
     __calibration: Optional[InterpolatedRCDCalibrationCurve] = field(default=None, init=False, repr=False)
     """Interpolated RCD calibration curve object, which is stored in a member variable so it is loaded once and only once"""
 
+    current_seed: Optional[int] = None
+    """Seed used for the current MCMC run. None indicates a random seed will be generated."""
+
     def get_working_directory(self) -> pathlib.Path:
         """Get the working directory to be used for dynamically created files
 

--- a/src/polychron/presenters/CalibrateModelSelectPresenter.py
+++ b/src/polychron/presenters/CalibrateModelSelectPresenter.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from ..Config import get_config
 from ..interfaces import Mediator
 from ..models.ProjectSelection import ProjectSelection
@@ -11,9 +13,13 @@ class CalibrateModelSelectPresenter(PopupPresenter[CalibrateModelSelectView, Pro
     Formerly `popupWindow8`, used from "tool > Calibrate multiple models from project"
     """
 
-    def __init__(self, mediator: Mediator, view: CalibrateModelSelectView, model: ProjectSelection) -> None:
+    def __init__(
+        self, mediator: Mediator, view: CalibrateModelSelectView, model: ProjectSelection, seed: Optional[int]
+    ) -> None:
         # Call the parent class' constructor
         super().__init__(mediator, view, model)
+
+        self.seed = seed
 
         # Bind buttons
         self.view.bind_ok_button(self.on_ok_button)
@@ -66,6 +72,7 @@ class CalibrateModelSelectPresenter(PopupPresenter[CalibrateModelSelectView, Pro
                     if project.has_model(model_name):
                         model = project.get_model(model_name)
                         if model is not None and model.load_check:
+                            model.apply_seed(self.seed)
                             (
                                 model.mcmc_data.contexts,
                                 model.mcmc_data.accept_samples_context,

--- a/src/polychron/presenters/DatingResultsPresenter.py
+++ b/src/polychron/presenters/DatingResultsPresenter.py
@@ -87,18 +87,6 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
             name = name[: -len("_interpolated")]
         return name
 
-    def get_display_seed(self) -> str:
-        model_model = self.model.current_model
-        if model_model is None:
-            return ""
-
-        seed = getattr(model_model, "seed", None)
-
-        if seed is None:
-            return "Seed: random"
-
-        return f"Seed: {seed}"
-
     def update_view(self) -> None:
         # Ensure content is correct when switching tab
         self.chronograph_render_post()

--- a/src/polychron/presenters/DatingResultsPresenter.py
+++ b/src/polychron/presenters/DatingResultsPresenter.py
@@ -87,6 +87,18 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
             name = name[: -len("_interpolated")]
         return name
 
+    def get_display_seed(self) -> str:
+        model_model = self.model.current_model
+        if model_model is None:
+            return ""
+
+        seed = getattr(model_model, "current_seed", None)
+
+        if seed is None:
+            return "Seed: random"
+
+        return f"Seed: {seed}"
+
     def update_view(self) -> None:
         # Ensure content is correct when switching tab
         self.chronograph_render_post()

--- a/src/polychron/presenters/DatingResultsPresenter.py
+++ b/src/polychron/presenters/DatingResultsPresenter.py
@@ -103,8 +103,14 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
         # Ensure content is correct when switching tab
         self.chronograph_render_post()
 
-        if hasattr(self.view, "set_curve_name"):
-            self.view.set_curve_name(self._get_display_curve_name())
+        model_model = self.model.current_model
+        if model_model is None:
+            return
+
+        self.view.set_curve_name(self._get_display_curve_name())
+
+        seed = model_model.mcmc_data.seed
+        self.view.set_seedlabel(seed)
 
     def get_window_title_suffix(self) -> str | None:
         if self.model.current_project_name and self.model.current_model_name:

--- a/src/polychron/presenters/DatingResultsPresenter.py
+++ b/src/polychron/presenters/DatingResultsPresenter.py
@@ -92,7 +92,7 @@ class DatingResultsPresenter(FramePresenter[DatingResultsView, ProjectSelection]
         if model_model is None:
             return ""
 
-        seed = getattr(model_model, "current_seed", None)
+        seed = getattr(model_model, "seed", None)
 
         if seed is None:
             return "Seed: random"

--- a/src/polychron/presenters/MCMCProgressPresenter.py
+++ b/src/polychron/presenters/MCMCProgressPresenter.py
@@ -23,7 +23,7 @@ class MCMCProgressPresenter(PopupPresenter[MCMCProgressView, Model]):
     def update_view(self) -> None:
         pass
 
-    def run(self) -> None:
+    def run(self, seed=None) -> None:
         """Runs model calibration for the current model"""
         # Set progress to none
         self.view.update_progress(0)
@@ -65,3 +65,15 @@ class MCMCProgressPresenter(PopupPresenter[MCMCProgressView, Model]):
         if name.endswith("_interpolated"):
             name = name[: -len("_interpolated")]
         return name
+
+    def get_display_seed(self) -> str:
+        model_model = self.model.current_model
+        if model_model is None:
+            return ""
+
+        seed = getattr(model_model, "current_seed", None)
+
+        if seed is None:
+            return "Seed: random"
+
+        return f"Seed: {seed}"

--- a/src/polychron/presenters/MCMCProgressPresenter.py
+++ b/src/polychron/presenters/MCMCProgressPresenter.py
@@ -27,8 +27,6 @@ class MCMCProgressPresenter(PopupPresenter[MCMCProgressView, Model]):
     def run(self, seed=None) -> None:
         """Runs model calibration for the current model"""
 
-        self.model.mcmc_data.seed = seed
-
         # Set progress to none
         self.view.update_progress(0)
         # Use the view as the writable object for progress updates
@@ -53,6 +51,8 @@ class MCMCProgressPresenter(PopupPresenter[MCMCProgressView, Model]):
         self.model.mcmc_check = True
         # Update the calibration curve used for the MCMCdata
         self.model.mcmc_data.calibration_curve_name = self.model.calibration_curve_name
+
+        self.model.mcmc_data.seed = self.model.seed
         # Save the mcmc data to disk
         self.model.mcmc_data.save(self.model.get_working_directory(), self.model.group_df, get_config().verbose)
 

--- a/src/polychron/presenters/MCMCProgressPresenter.py
+++ b/src/polychron/presenters/MCMCProgressPresenter.py
@@ -27,6 +27,7 @@ class MCMCProgressPresenter(PopupPresenter[MCMCProgressView, Model]):
     def run(self, seed=None) -> None:
         """Runs model calibration for the current model"""
 
+        self.model.apply_seed(seed)
         # Set progress to none
         self.view.update_progress(0)
         # Use the view as the writable object for progress updates

--- a/src/polychron/presenters/MCMCProgressPresenter.py
+++ b/src/polychron/presenters/MCMCProgressPresenter.py
@@ -26,6 +26,9 @@ class MCMCProgressPresenter(PopupPresenter[MCMCProgressView, Model]):
 
     def run(self, seed=None) -> None:
         """Runs model calibration for the current model"""
+
+        self.model.mcmc_data.seed = seed
+
         # Set progress to none
         self.view.update_progress(0)
         # Use the view as the writable object for progress updates
@@ -68,11 +71,8 @@ class MCMCProgressPresenter(PopupPresenter[MCMCProgressView, Model]):
         return name
 
     def get_display_seed(self) -> str:
-        model_model = self.model.current_model
-        if model_model is None:
-            return ""
-
-        seed = getattr(model_model, "current_seed", None)
+        """Return a user-friendly display string for the seed used in this run."""
+        seed = getattr(self.model.mcmc_data, "seed", None)
 
         if seed is None:
             return "Seed: random"

--- a/src/polychron/presenters/MCMCProgressPresenter.py
+++ b/src/polychron/presenters/MCMCProgressPresenter.py
@@ -19,6 +19,7 @@ class MCMCProgressPresenter(PopupPresenter[MCMCProgressView, Model]):
         self.update_view()
 
         self.view.set_curve_name(self._get_display_curve_name())
+        self.view.set_seed(self.get_display_seed())
 
     def update_view(self) -> None:
         pass

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -213,7 +213,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         # Ensure it is visible and on top
         popup_presenter.display_view(wait=False)
         # Run the calibration
-        popup_presenter.run(seed = seed)
+        popup_presenter.run(seed=seed)
         # Close the popup (formerly .cleanup)
         popup_presenter.close_view()
         # Change to the DatingResults tab

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -202,16 +202,9 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         if seed == "cancel":
             return
 
-        # Store seed so you can track/display it later
-        model_model.current_seed = seed
-
         if seed is None:
             # Generate and record a random seed
             seed = np.random.randint(0, 2**32 - 1)
-
-        # Store and apply seed
-        model_model.current_seed = seed
-        np.random.seed(seed)
 
         # Create the popup presenter and view
         popup_presenter = MCMCProgressPresenter(self.mediator, MCMCProgressView(self.view), model_model)
@@ -220,13 +213,11 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         # Ensure it is visible and on top
         popup_presenter.display_view(wait=False)
         # Run the calibration
-        popup_presenter.run()
+        popup_presenter.run(seed = seed)
         # Close the popup (formerly .cleanup)
         popup_presenter.close_view()
         # Change to the DatingResults tab
         self.mediator.switch_presenter("DatingResults")
-
-        popup_presenter.run(seed=seed)
 
     def popup_calibrate_multiple(self) -> None:
         """Callback function for when Tools -> Calibrate multiple models from project is selected

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -201,8 +201,6 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         if seed == "cancel":
             return
 
-        model_model.mcmc_data.seed = seed
-
         # Create the popup presenter and view
         popup_presenter = MCMCProgressPresenter(self.mediator, MCMCProgressView(self.view), model_model)
         model_model.mcmc_data.seed = seed
@@ -223,7 +221,14 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         Formerly `popupWindow8`
         """
-        popup_presenter = CalibrateModelSelectPresenter(self.mediator, CalibrateModelSelectView(self.view), self.model)
+        seed = self.view.ask_for_seed()
+
+        if seed == "cancel":
+            return
+
+        popup_presenter = CalibrateModelSelectPresenter(
+            self.mediator, CalibrateModelSelectView(self.view), self.model, seed
+        )
         # Ensure it is visible and on top
         popup_presenter.display_view(wait=True)
 

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, List
 
 import networkx as nx
-import numpy as np
 import pandas as pd
 
 from ..interfaces import Mediator
@@ -202,9 +201,7 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         if seed == "cancel":
             return
 
-        if seed is None:
-            # Generate and record a random seed
-            seed = np.random.randint(0, 2**32 - 1)
+        model_model.mcmc_data.seed = seed
 
         # Create the popup presenter and view
         popup_presenter = MCMCProgressPresenter(self.mediator, MCMCProgressView(self.view), model_model)

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -208,8 +208,8 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
 
         # Create the popup presenter and view
         popup_presenter = MCMCProgressPresenter(self.mediator, MCMCProgressView(self.view), model_model)
-
-        popup_presenter.view.set_seed(model_model.current_seed)
+        model_model.mcmc_data.seed = seed
+        popup_presenter.view.set_seed(seed)
         # Ensure it is visible and on top
         popup_presenter.display_view(wait=False)
         # Run the calibration

--- a/src/polychron/presenters/ModelPresenter.py
+++ b/src/polychron/presenters/ModelPresenter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, List
 
 import networkx as nx
+import numpy as np
 import pandas as pd
 
 from ..interfaces import Mediator
@@ -196,8 +197,26 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
             )
             return
 
+        seed = self.view.ask_for_seed()
+
+        if seed == "cancel":
+            return
+
+        # Store seed so you can track/display it later
+        model_model.current_seed = seed
+
+        if seed is None:
+            # Generate and record a random seed
+            seed = np.random.randint(0, 2**32 - 1)
+
+        # Store and apply seed
+        model_model.current_seed = seed
+        np.random.seed(seed)
+
         # Create the popup presenter and view
         popup_presenter = MCMCProgressPresenter(self.mediator, MCMCProgressView(self.view), model_model)
+
+        popup_presenter.view.set_seed(model_model.current_seed)
         # Ensure it is visible and on top
         popup_presenter.display_view(wait=False)
         # Run the calibration
@@ -206,6 +225,8 @@ class ModelPresenter(FramePresenter[ModelView, ProjectSelection]):
         popup_presenter.close_view()
         # Change to the DatingResults tab
         self.mediator.switch_presenter("DatingResults")
+
+        popup_presenter.run(seed=seed)
 
     def popup_calibrate_multiple(self) -> None:
         """Callback function for when Tools -> Calibrate multiple models from project is selected

--- a/src/polychron/views/DatingResultsView.py
+++ b/src/polychron/views/DatingResultsView.py
@@ -112,13 +112,17 @@ class DatingResultsView(FrameView):
         self.littlecanvas_label = tk.Canvas(
             self.canvas, bd=0, bg="#CC5F00", selectborderwidth=0, highlightthickness=0, insertwidth=0
         )
-        self.littlecanvas_label.place(relx=0.6, rely=0.011, relwidth=0.23, relheight=0.027)
+        self.littlecanvas_label.place(relx=0.6, rely=0.011, relwidth=0.30, relheight=0.027)
         self.littlecanvas_label_id = self.littlecanvas_label.create_text(10, 5, anchor="nw", fill="white")
         self.littlecanvas_label.itemconfig(
             self.littlecanvas_label_id, text="Posterior densities", font="helvetica 12 bold"
         )
         self.curve_badge_id = self.littlecanvas_label.create_text(
             300, 5, anchor="ne", fill="white", font="helvetica 12 bold"
+        )
+
+        self.seed_badge_id = self.littlecanvas_label.create_text(
+            390, 5, anchor="ne", fill="white", font="helvetica 12 bold"
         )
 
         self.littlecanvas_a_label = tk.Canvas(

--- a/src/polychron/views/DatingResultsView.py
+++ b/src/polychron/views/DatingResultsView.py
@@ -591,3 +591,6 @@ class DatingResultsView(FrameView):
         if curve_name.endswith("_interpolated"):
             curve_name = curve_name[: -len("_interpolated")]
         self.littlecanvas_label.itemconfig(self.curve_badge_id, text=f"Curve: {curve_name}")
+
+    def set_seed(self, seed: int) -> None:
+        self.littlecanvas_label.itemconfig(self.seed_badge_id, text=f"Seed: {seed}")

--- a/src/polychron/views/DatingResultsView.py
+++ b/src/polychron/views/DatingResultsView.py
@@ -596,5 +596,5 @@ class DatingResultsView(FrameView):
             curve_name = curve_name[: -len("_interpolated")]
         self.littlecanvas_label.itemconfig(self.curve_badge_id, text=f"Curve: {curve_name}")
 
-    def set_seed(self, seed: int) -> None:
+    def set_seedlabel(self, seed: int) -> None:
         self.littlecanvas_label.itemconfig(self.seed_badge_id, text=f"Seed: {seed}")

--- a/src/polychron/views/DatingResultsView.py
+++ b/src/polychron/views/DatingResultsView.py
@@ -112,7 +112,7 @@ class DatingResultsView(FrameView):
         self.littlecanvas_label = tk.Canvas(
             self.canvas, bd=0, bg="#CC5F00", selectborderwidth=0, highlightthickness=0, insertwidth=0
         )
-        self.littlecanvas_label.place(relx=0.6, rely=0.011, relwidth=0.30, relheight=0.027)
+        self.littlecanvas_label.place(relx=0.6, rely=0.011, relwidth=0.32, relheight=0.027)
         self.littlecanvas_label_id = self.littlecanvas_label.create_text(10, 5, anchor="nw", fill="white")
         self.littlecanvas_label.itemconfig(
             self.littlecanvas_label_id, text="Posterior densities", font="helvetica 12 bold"
@@ -122,7 +122,7 @@ class DatingResultsView(FrameView):
         )
 
         self.seed_badge_id = self.littlecanvas_label.create_text(
-            390, 5, anchor="ne", fill="white", font="helvetica 12 bold"
+            415, 5, anchor="ne", fill="white", font="helvetica 12 bold"
         )
 
         self.littlecanvas_a_label = tk.Canvas(

--- a/src/polychron/views/MCMCProgressView.py
+++ b/src/polychron/views/MCMCProgressView.py
@@ -35,6 +35,9 @@ class MCMCProgressView(PopupView):
         self.progress_bar = ttk.Progressbar(self.backcanvas, orient=tk.HORIZONTAL, length=400, mode="indeterminate")
         self.progress_bar.place(relx=0.2, rely=0.56)
 
+        self.curve_name = ""
+        self.seed = None
+
     def update_progress(self, percent: int) -> None:
         """Update the progress bar and text label with current progress
 
@@ -65,8 +68,26 @@ class MCMCProgressView(PopupView):
             # If there was more than one match, instead print to console.
             print(f"{text}")
 
-    def set_curve_name(self, curve_name: str) -> None:
-        """Update the title label with the selected calibration curve."""
-        title = f"MCMC in progress - Calibration curve: {curve_name}"
+    def update_title(self) -> None:
+        parts = ["MCMC in progress"]
+
+        if self.curve_name:
+            parts.append(f"Calibration curve: {self.curve_name}")
+
+        if self.seed is not None:
+            parts.append(f"Seed: {self.seed}")
+
+        title = " - ".join(parts)
+
         self.title(title)
         self.title_label.config(text=title)
+
+    def set_curve_name(self, curve_name: str) -> None:
+        """Update the calibration curve used."""
+        self.curve_name = curve_name
+        self.update_title()
+
+    def set_seed(self, seed: int) -> None:
+        """Update the seed used for the MCMC run."""
+        self.seed = seed
+        self.update_title()

--- a/src/polychron/views/ModelView.py
+++ b/src/polychron/views/ModelView.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import tkinter as tk
-from tkinter import ttk
+from tkinter import simpledialog, ttk
 from typing import Any, Callable, List, Tuple
 
 import pandas as pd
@@ -190,6 +190,23 @@ class ModelView(FrameView):
         )
         self.datalittlecanvas.place(relx=0.015, rely=0.015, relwidth=0.97, relheight=0.97)
         tk.Misc.lift(self.littlecanvas)
+
+    def ask_for_seed(self):
+        """Return seed (int), None for random, or 'cancel'."""
+
+        fix_seed = self.messagebox_askyesno(
+            title="MCMC Seed", message="Do you want to fix the random seed for this run?"
+        )
+
+        if fix_seed:
+            seed = simpledialog.askinteger("Enter Seed", "Enter an integer seed value:", parent=self.parent)
+
+            if seed is None:
+                return "cancel"
+
+            return seed
+
+        return None
 
     def get_testmenu_selection(self) -> str:
         """Return the most recent value for the testmenu"""

--- a/tests/polychron/presenters/test_CalibrateModelSelectPresenter.py
+++ b/tests/polychron/presenters/test_CalibrateModelSelectPresenter.py
@@ -52,7 +52,7 @@ class TestCalibrateModelSelectPresenter:
         model = self.project_selection
 
         # Instantiate the Presenter
-        presenter = CalibrateModelSelectPresenter(mock_mediator, mock_view, model)
+        presenter = CalibrateModelSelectPresenter(mock_mediator, mock_view, model, None)
 
         # Assert that presenter attributes are set as intended
         assert presenter.mediator == mock_mediator
@@ -82,7 +82,7 @@ class TestCalibrateModelSelectPresenter:
         model = self.project_selection
 
         # Instantiate the Presenter
-        presenter = CalibrateModelSelectPresenter(mock_mediator, mock_view, model)
+        presenter = CalibrateModelSelectPresenter(mock_mediator, mock_view, model, None)
 
         # Call the method to be tested, and Assert that view.update_model_list was most recently called with an empty list, as the mock projects directory does not have an active project
         presenter.update_view()
@@ -113,7 +113,7 @@ class TestCalibrateModelSelectPresenter:
         model = self.project_selection
 
         # Instantiate the Presenter
-        presenter = CalibrateModelSelectPresenter(mock_mediator, mock_view, model)
+        presenter = CalibrateModelSelectPresenter(mock_mediator, mock_view, model, None)
 
         # Call on_ok_button when the current project is not valid, which should just call the parents close view (which has been mocked out)
         with patch(
@@ -177,7 +177,7 @@ class TestCalibrateModelSelectPresenter:
         model = self.project_selection
 
         # Instantiate the Presenter
-        presenter = CalibrateModelSelectPresenter(mock_mediator, mock_view, model)
+        presenter = CalibrateModelSelectPresenter(mock_mediator, mock_view, model, None)
 
         # Call the method
         presenter.on_select_all()


### PR DESCRIPTION
The user should be able to assign a seed to each mcmc run now. Clicking on calibrate model opens a popup box that asks if the user whats to assign a specific seed. This popup box is similar to the one which prompts the user to specify whether any sample is residual or intrusive. 

I have not added this to the "calibrate multiple models" case but that shouldn't take too long wanted to make sure the seeding worked properly first.

Not exactly sure where the best place would be to display the seed number in the results page, currently it only shows in the mcmc progress bar next to the calibration curve name.