### PR TITLE
Deps: Require pandas < 3 (and >= 2.2.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "networkx>=3.4; python_version >= '3.10'", # required for https://github.com/networkx/networkx/pull/7588, but not available for py 3.9
     "networkx>=2; python_version < '3.10'",
     "packaging",
-    "pandas>=2",
+    "pandas>=2.2.2,<3",
     "pydot<4", # pydot 4 includes an api break which requires network 3.5 to support.
     "pyyaml",
     "ttkthemes",


### PR DESCRIPTION
Pandas 2.2.2 adds numpy 2 support, so is the true minimum supported pandas for polychron.

Pandas 3.x is causing a test failure, so is being disabled as a temporary fix

Part of #250